### PR TITLE
Upgrade lower tracks of Google Play

### DIFF
--- a/mozapkpublisher/apk_metadata.py
+++ b/mozapkpublisher/apk_metadata.py
@@ -1,0 +1,20 @@
+from xml.dom import minidom
+from zipfile import ZipFile
+
+from axmlparserpy.axmlprinter import AXMLPrinter
+
+
+# Even though a class called APK exists in axmlparserpy, it's not compatible with Python 3 (unlike the rest of the
+# library). That's why a simpler version is defined here
+def extract_metadata_from_apk(file_name):
+    with ZipFile(file_name) as apk_file:
+        with apk_file.open('AndroidManifest.xml') as manifest_file:
+            manifest_binary_content = manifest_file.read()
+
+    manifest_string_content = AXMLPrinter(manifest_binary_content).getBuff()
+    xml_manifest = minidom.parseString(manifest_string_content)
+
+    return {
+        # Google Play uses integers
+        'version_code': int(xml_manifest.documentElement.getAttribute('android:versionCode')),
+    }

--- a/mozapkpublisher/apk_metadata.py
+++ b/mozapkpublisher/apk_metadata.py
@@ -15,6 +15,7 @@ def extract_metadata_from_apk(file_name):
     xml_manifest = minidom.parseString(manifest_string_content)
 
     return {
+        'package_name': xml_manifest.documentElement.getAttribute('package'),
         # Google Play uses integers
         'version_code': int(xml_manifest.documentElement.getAttribute('android:versionCode')),
     }

--- a/mozapkpublisher/googleplay.py
+++ b/mozapkpublisher/googleplay.py
@@ -17,9 +17,8 @@ import httplib2
 from oauth2client.service_account import ServiceAccountCredentials
 from apiclient.discovery import build
 
-# Google play has currently 3 tracks. Rollout deploys
-# to a limited percentage of users
-TRACK_VALUES = ('production', 'beta', 'alpha', 'rollout')
+# Google play has currently 3 tracks. Rollout deploys to a limited percentage of users.
+TRACK_VALUES = ('production', 'rollout', 'beta', 'alpha')
 
 PACKAGE_NAME_VALUES = {
     'org.mozilla.fennec_aurora': 'aurora',
@@ -54,3 +53,14 @@ def connect(service_account, credentials_file_path):
     service = build('androidpublisher', 'v2', http=http)
 
     return service
+
+
+def get_lower_to_initial_tracks(initial_track):
+    index = TRACK_VALUES.index(initial_track)
+    tracks_sublist = list(TRACK_VALUES[index:])
+    tracks_sublist.reverse()
+
+    if initial_track == 'production':
+        # Rollout is not a real track, and must not be updated if production is being set.
+        tracks_sublist.remove('rollout')
+    return tracks_sublist

--- a/mozapkpublisher/push_apk.py
+++ b/mozapkpublisher/push_apk.py
@@ -31,13 +31,13 @@ class PushAPK(Base):
     @classmethod
     def _init_parser(cls):
         cls.parser = ArgumentParser(
-            description="""Upload the apk of a Firefox app on Google play.
+            description='''Upload Firefox for Android APKs onto Google Play Store.
 
-    Example for a beta upload:
+    Example for Firefox for Android Beta:
     $ python push_apk.py --package-name org.mozilla.firefox_beta --track production \
-    --service-account foo@developer.gserviceaccount.com --credentials key.p12 \
-    --apk-x86=/path/to/fennec-XX.0bY.multi.android-i386.apk \
-    --apk-armv7-v15=/path/to/fennec-XX.0bY.multi.android-arm-v15.apk""",
+--service-account foo@developer.gserviceaccount.com --credentials key.p12 \
+--apk-x86=/path/to/fennec-XX.0bY.multi.android-i386.apk \
+--apk-armv7-v15=/path/to/fennec-XX.0bY.multi.android-arm-v15.apk''',
             formatter_class=argparse.RawDescriptionHelpFormatter,
         )
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,5 @@ pyOpenSSL==16.1.0 \
 #    --hash=sha512:e694c2bfec2e3f585b15b47b66eef0de0b10f7c6abdb49ee33f9c7acf1b64aba9d1c08500414c85c2cc5b6d2e0215c127329d38f62de687f8f1b2140e3bd8225
 requests==2.11.1 \
 #    --hash=sha512:9e92419e11ec8b45d0fdf1b4655476c83e20da043a8e23b8d33f29e73eecb82f6bc929ea3c73ccec2d283caec0b721cd349fc76bd925f617df2f7ddfba14e57e
+# TODO before merging PR: 0.0.2 isn't published yet. Waiting on https://github.com/kzjeef/AxmlParserPY/pull/3
+AxmlParserPY==0.0.2


### PR DESCRIPTION
Inspired from [this feature](https://github.com/Triple-T/gradle-play-publisher#untrack-conflicting-versions) [implemented there](https://github.com/Triple-T/gradle-play-publisher/blob/8a2fa9064bc50fcd276b3c3d00381d2f4f873296/src/main/groovy/de/triplet/gradle/play/PlayPublishApkTask.groovy#L45). The PR adds a new flag onto the command line, allowing to updates lower tracks to the version codes being pushed.

For instance:

> - I toggle `--untrack-old`
>   - Both alpha and beta tracks are at version codes `11` and `12`.  I upload APKs with version `21` and `22` on the **beta** track => alpha gets updated as well.
>   - Alpha and beta tracks are still at `11` and `12`.  I upload APKs with version `21` and `22` on the **alpha** track => beta remains untouched.
>   - Beta tracks is at `11` and `12`, but alpha is at `31` and `32`.  I upload APKs with version `21` and `22` on the **beta** track => alpha isn't changed.
> - If `--untrack-old` isn't provided, the behavior remains the same as it used to be without the PR.

In order to preemptively know the version codes , apks are open and `AndroidManifest.xml` is read. Because this xml file is actually a binary one, I imported a [3rd party lib](https://pypi.python.org/pypi/AxmlParserPY). The project doesn't seem to too active and I'm not sure what the binary parsing exactly does. @arroway , would you think this library is okay to with?  
Also, we'll need to use a newer version of that lib (so it'll be compatible with python 3). I opened a PR for that.

Code-wise, I refactor `upload_apks()` to be smaller. I think we can even make this file purely functional, but I didn't want to make too many changes.
I also added a `--no-commit` option in order to make development simpler (no need to comment out the commit lines, anymore)

One last thing: Python 2 compatibility is currently broken. I can bring back the compatibility, but I'm not sure of the advantages.

r? @sylvestre 
