### PR TITLE
Fix what's new message not appearing in the logs

### DIFF
--- a/mozapkpublisher/base.py
+++ b/mozapkpublisher/base.py
@@ -35,7 +35,7 @@ class Base(object):
 
         flatten_args = [str(item) for tuples in args_with_unary_arguments_alone for item in tuples]
 
-        logger.debug('dict_ converveted into these args: %s', flatten_args)
+        logger.debug('dict_ converted into these args: {}'.format(flatten_args))
         return flatten_args
 
 

--- a/mozapkpublisher/get_apk.py
+++ b/mozapkpublisher/get_apk.py
@@ -91,11 +91,11 @@ class GetAPK(Base):
     def generate_url(self, version, build, locale, api_suffix, arch_file):
         if self.config.latest_nightly or self.config.latest_aurora:
             code = "central" if self.config.latest_nightly else "aurora"
-            return ("%s/nightly/latest-mozilla-%s-android-%s/fennec-%s.%s.android-%s") % (
+            return '{}/nightly/latest-mozilla-{}-android-{}/fennec-{}.{}.android-{}'.format(
                 self.base_url, code, api_suffix, version, locale, arch_file
             )
 
-        return ("%s/candidates/%s-candidates/build%s/%s%s/%s/fennec-%s.%s.%s%s") % (
+        return '{}/candidates/{}-candidates/build{}/{}{}/{}/fennec-{}.{}.{}{}'.format(
             self.base_url, version, build, self.android_prefix, api_suffix, locale, version, locale,
             self.android_prefix, arch_file
         )

--- a/mozapkpublisher/push_apk.py
+++ b/mozapkpublisher/push_apk.py
@@ -98,7 +98,7 @@ def _push_whats_new(edit_service, release_channel, apk_version_code):
         play_store_locale = store_l10n.locale_mapping(locale)
 
         edit_service.update_apk_listings(play_store_locale, apk_version_code, body={'recentChanges': whatsnew})
-        logger.info('Locale "%s" what\'s new has been updated to "%s"'.format(play_store_locale, whatsnew))
+        logger.info(u'Locale "{}" what\'s new has been updated to "{}"'.format(play_store_locale, whatsnew))
 
 
 def main(name=None):


### PR DESCRIPTION
Thanks for spotting it @sylvestre ! r? 

I tested the patch manually with both python 2 and 3. I got the warning message in one case but not the other. Like said in that message, I also got some characters stripped