### PR TITLE
push_apk: remove special-casing of en-GB locale

### DIFF
--- a/mozapkpublisher/push_apk.py
+++ b/mozapkpublisher/push_apk.py
@@ -89,10 +89,6 @@ def _push_whats_new(edit_service, release_channel, apk_version_code):
     locales.append(u'en-US')
 
     for locale in locales:
-        if locale == "en-GB":
-            logger.info("Ignoring en-GB as locale")
-            continue
-
         translation = store_l10n.get_translation(release_channel, locale)
         whatsnew = translation.get('whatsnew')
         play_store_locale = store_l10n.locale_mapping(locale)

--- a/mozapkpublisher/test/test_push_apk.py
+++ b/mozapkpublisher/test/test_push_apk.py
@@ -113,8 +113,7 @@ def test_upload_apk_with_whats_new(monkeypatch):
 
     expected_locales = (
         ('es-US', 'Mire a esta caracteristica'),
-        # Unlike what we could infer from the data input, en-GB is NOT converted into en-US.
-        # en-GB is not meant to be updated and en-US is added to list_locales
+        ('en-GB', 'Check out this cool feature!'),
         ('en-US', 'Check out this cool feature!'),
     )
 
@@ -124,7 +123,7 @@ def test_upload_apk_with_whats_new(monkeypatch):
                 'recentChanges': whats_new
             })
 
-    assert edit_service_mock.update_apk_listings.call_count == 4
+    assert edit_service_mock.update_apk_listings.call_count == 6
     edit_service_mock.commit_transaction.assert_called_once_with()
 
 


### PR DESCRIPTION
Requested by flod, and things seem to work well enough without that.