### PR TITLE
Bug 1349039 - Add listings of new locales during push_apk

### DIFF
--- a/mozapkpublisher/googleplay.py
+++ b/mozapkpublisher/googleplay.py
@@ -108,16 +108,14 @@ class EditService(object):
         logger.debug('Listing body: {}'.format(body))
 
     @transaction_required
-    def update_apk_listings(self, language, apk_version_code, body):
+    def update_whats_new(self, language, apk_version_code, whats_new):
         response = self._service.apklistings().update(
             editId=self._edit_id, packageName=self._package_name, language=language,
-            apkVersionCode=apk_version_code,
-            body=body
+            apkVersionCode=apk_version_code, body={'recentChanges': whats_new}
         ).execute()
-        logger.info('Listing for language "{}" (and APK with version code "{}") has been updated'.format(
-            language, apk_version_code
+        logger.info('What\'s new listing for ("{}", "{}") has been updated to: "{}"'.format(
+            language, apk_version_code, whats_new
         ))
-        logger.debug('Listing body: {}', body)
         logger.debug('Listing response: {}', response)
 
 

--- a/mozapkpublisher/googleplay.py
+++ b/mozapkpublisher/googleplay.py
@@ -100,12 +100,16 @@ class EditService(object):
         logger.debug('Track update response: {}'.format(response))
 
     @transaction_required
-    def update_listings(self, language, body):
+    def update_listings(self, language, title, full_description, short_description):
+        body = {
+            'fullDescription': full_description,
+            'shortDescription': short_description,
+            'title': title,
+        }
         self._service.listings().update(
             editId=self._edit_id, packageName=self._package_name, language=language, body=body
         ).execute()
-        logger.info('Listing for language "{}" has been updated.'.format(language))
-        logger.debug('Listing body: {}'.format(body))
+        logger.info('Listing for language "{}" has been updated with: {}'.format(language, body))
 
     @transaction_required
     def update_whats_new(self, language, apk_version_code, whats_new):

--- a/mozapkpublisher/push_apk.py
+++ b/mozapkpublisher/push_apk.py
@@ -63,11 +63,8 @@ https://github.com/mozilla-l10n/stores_l10n/issues/71). Skipping what\'s new.')
             else:
                 _push_whats_new(edit_service, release_channel, apk_response['versionCode'])
 
-        upload_body = {u'versionCodes': _check_and_get_flatten_version_codes(apks)}
-        if self.config.rollout_percentage is not None:
-            upload_body[u'userFraction'] = self.config.rollout_percentage / 100.0
-
-        edit_service.update_track(self.config.track, upload_body)
+        version_codes = _check_and_get_flatten_version_codes(apks)
+        edit_service.update_track(self.config.track, version_codes, self.config.rollout_percentage)
         edit_service.commit_transaction()
 
     def run(self):

--- a/mozapkpublisher/push_apk.py
+++ b/mozapkpublisher/push_apk.py
@@ -89,11 +89,9 @@ def _push_whats_new(edit_service, release_channel, apk_version_code):
 
     for locale in locales:
         translation = store_l10n.get_translation(release_channel, locale)
-        whatsnew = translation.get('whatsnew')
+        whats_new = translation.get('whatsnew')
         play_store_locale = store_l10n.locale_mapping(locale)
-
-        edit_service.update_apk_listings(play_store_locale, apk_version_code, body={'recentChanges': whatsnew})
-        logger.info(u'Locale "{}" what\'s new has been updated to "{}"'.format(play_store_locale, whatsnew))
+        edit_service.update_whats_new(play_store_locale, apk_version_code, whats_new)
 
 
 def _check_and_get_flatten_version_codes(apks):

--- a/mozapkpublisher/test/test_googleplay.py
+++ b/mozapkpublisher/test/test_googleplay.py
@@ -1,5 +1,6 @@
 import argparse
 import pytest
+import random
 import tempfile
 
 try:
@@ -42,16 +43,38 @@ def test_add_general_google_play_arguments_wrong_package():
 def set_up_edit_service_mock(_monkeypatch):
     general_service_mock = MagicMock()
     edit_service_mock = MagicMock()
+    new_transaction_mock = MagicMock()
+
+    new_transaction_mock.execute = lambda: {'id': random.randint(0, 1000)}
+    edit_service_mock.insert = lambda body, packageName: new_transaction_mock
     general_service_mock.edits = lambda: edit_service_mock
 
     _monkeypatch.setattr('mozapkpublisher.googleplay._connect', lambda _, __: general_service_mock)
     return edit_service_mock
 
 
-def test_edit_service_starts_new_transaction(monkeypatch):
+def test_edit_service_starts_new_transaction_upon_init(monkeypatch):
     set_up_edit_service_mock(monkeypatch)
     edit_service = EditService('service_account', 'credentials_file_path', 'dummy_package_name')
     edit_service.upload_apk(apk_path='/path/to/dummy.apk')
+
+
+def test_edit_service_raises_error_if_no_transaction_started(monkeypatch):
+    set_up_edit_service_mock(monkeypatch)
+    edit_service = EditService('service_account', 'credentials_file_path', 'dummy_package_name')
+    edit_service.commit_transaction()
+    with pytest.raises(NoTransactionError):
+        edit_service.upload_apk(apk_path='/path/to/dummy.apk')
+
+
+def test_edit_service_starts_new_transaction_manually(monkeypatch):
+    set_up_edit_service_mock(monkeypatch)
+    edit_service = EditService('service_account', 'credentials_file_path', 'dummy_package_name')
+    old_edit_id = edit_service._edit_id
+    edit_service.commit_transaction()
+    edit_service.start_new_transaction()
+
+    assert edit_service._edit_id != old_edit_id
 
 
 def test_edit_service_supports_dry_run(monkeypatch):
@@ -66,27 +89,77 @@ def test_edit_service_supports_dry_run(monkeypatch):
     edit_service_mock.commit.assert_called_once_with(editId=current_edit_id, packageName='dummy_package_name')
 
 
-def test_edit_service_raises_error_if_no_transaction_started(monkeypatch):
-    set_up_edit_service_mock(monkeypatch)
-    edit_service = EditService('service_account', 'credentials_file_path', 'dummy_package_name')
-    edit_service.commit_transaction()
-    with pytest.raises(NoTransactionError):
-        edit_service.upload_apk(apk_path='/path/to/dummy.apk')
-
-
 def test_upload_apk_returns_files_metadata(monkeypatch):
     edit_mock = set_up_edit_service_mock(monkeypatch)
-    upload_mock = MagicMock()
-    upload_mock.execute = lambda: {
+    edit_mock.apks().upload().execute.return_value = {
         'binary': {'sha1': '1234567890abcdef1234567890abcdef12345678'}, 'versionCode': 2015012345
     }
-
-    apks_mock = MagicMock()
-    apks_mock.upload = lambda editId, packageName, media_body: upload_mock
-    edit_mock.apks = lambda: apks_mock
+    edit_mock.apks().upload.reset_mock()
 
     edit_service = EditService('service_account', 'credentials_file_path', 'dummy_package_name')
     response = edit_service.upload_apk(apk_path='/path/to/dummy.apk')
     assert response == {
         'binary': {'sha1': '1234567890abcdef1234567890abcdef12345678'}, 'versionCode': 2015012345
     }
+    edit_mock.apks().upload.assert_called_once_with(
+        editId=edit_service._edit_id,
+        packageName='dummy_package_name',
+        media_body='/path/to/dummy.apk',
+    )
+
+
+def test_update_track(monkeypatch):
+    edit_mock = set_up_edit_service_mock(monkeypatch)
+    edit_service = EditService('service_account', 'credentials_file_path', 'dummy_package_name')
+
+    edit_service.update_track('alpha', {u'versionCodes': ['2015012345', '2015012347']})
+    edit_mock.tracks().update.assert_called_once_with(
+        editId=edit_service._edit_id,
+        packageName='dummy_package_name',
+        track='alpha',
+        body={u'versionCodes': ['2015012345', '2015012347']}
+    )
+
+    edit_mock.tracks().update.reset_mock()
+    edit_service.update_track('rollout', {u'userFraction': 0.01, u'versionCodes': ['2015012345', '2015012347']})
+    edit_mock.tracks().update.assert_called_once_with(
+        editId=edit_service._edit_id,
+        packageName='dummy_package_name',
+        track='rollout',
+        body={u'userFraction': 0.01, u'versionCodes': ['2015012345', '2015012347']}
+    )
+
+
+def test_update_listings(monkeypatch):
+    edit_mock = set_up_edit_service_mock(monkeypatch)
+    edit_service = EditService('service_account', 'credentials_file_path', 'dummy_package_name')
+
+    edit_service.update_listings('en-GB', {
+        'title': 'Firefox for Android Beta',
+        'fullDescription': 'Long description',
+        'shortDescription': 'Short',
+    })
+    edit_mock.listings().update.assert_called_once_with(
+        editId=edit_service._edit_id,
+        packageName='dummy_package_name',
+        language='en-GB',
+        body={
+            'title': 'Firefox for Android Beta',
+            'fullDescription': 'Long description',
+            'shortDescription': 'Short',
+        }
+    )
+
+
+def test_update_apk_listings(monkeypatch):
+    edit_mock = set_up_edit_service_mock(monkeypatch)
+    edit_service = EditService('service_account', 'credentials_file_path', 'dummy_package_name')
+
+    edit_service.update_apk_listings('en-GB', '2015012345', {'recentChanges': 'Check out this cool feature!'})
+    edit_mock.apklistings().update.assert_called_once_with(
+        editId=edit_service._edit_id,
+        packageName='dummy_package_name',
+        language='en-GB',
+        apkVersionCode='2015012345',
+        body={'recentChanges': 'Check out this cool feature!'}
+    )

--- a/mozapkpublisher/test/test_googleplay.py
+++ b/mozapkpublisher/test/test_googleplay.py
@@ -151,11 +151,11 @@ def test_update_listings(monkeypatch):
     )
 
 
-def test_update_apk_listings(monkeypatch):
+def test_update_whats_new(monkeypatch):
     edit_mock = set_up_edit_service_mock(monkeypatch)
     edit_service = EditService('service_account', 'credentials_file_path', 'dummy_package_name')
 
-    edit_service.update_apk_listings('en-GB', '2015012345', {'recentChanges': 'Check out this cool feature!'})
+    edit_service.update_whats_new('en-GB', '2015012345', 'Check out this cool feature!')
     edit_mock.apklistings().update.assert_called_once_with(
         editId=edit_service._edit_id,
         packageName='dummy_package_name',

--- a/mozapkpublisher/test/test_googleplay.py
+++ b/mozapkpublisher/test/test_googleplay.py
@@ -134,11 +134,12 @@ def test_update_listings(monkeypatch):
     edit_mock = set_up_edit_service_mock(monkeypatch)
     edit_service = EditService('service_account', 'credentials_file_path', 'dummy_package_name')
 
-    edit_service.update_listings('en-GB', {
-        'title': 'Firefox for Android Beta',
-        'fullDescription': 'Long description',
-        'shortDescription': 'Short',
-    })
+    edit_service.update_listings(
+        'en-GB',
+        title='Firefox for Android Beta',
+        full_description='Long description',
+        short_description='Short',
+    )
     edit_mock.listings().update.assert_called_once_with(
         editId=edit_service._edit_id,
         packageName='dummy_package_name',

--- a/mozapkpublisher/test/test_push_apk.py
+++ b/mozapkpublisher/test/test_push_apk.py
@@ -90,10 +90,7 @@ def test_rollout_percentage(edit_service_mock, monkeypatch):
         config['rollout_percentage'] = valid_percentage
 
         PushAPK(config).run()
-        edit_service_mock.update_track.assert_called_once_with('rollout', {
-            u'versionCodes': ['0', '1'],
-            u'userFraction': valid_percentage / 100.0   # Ensure float in Python 2
-        })
+        edit_service_mock.update_track.assert_called_once_with('rollout', ['0', '1'], valid_percentage)
         edit_service_mock.update_track.reset_mock()
 
 
@@ -127,7 +124,7 @@ def test_upload_apk(edit_service_mock, monkeypatch):
     for apk_file in (apk_arm, apk_x86):
         edit_service_mock.upload_apk.assert_any_call(apk_file.name)
 
-    edit_service_mock.update_track.assert_called_once_with('alpha', {u'versionCodes': ['0', '1']})
+    edit_service_mock.update_track.assert_called_once_with('alpha', ['0', '1'], None)
     edit_service_mock.commit_transaction.assert_called_once_with()
 
 

--- a/mozapkpublisher/test/test_push_apk.py
+++ b/mozapkpublisher/test/test_push_apk.py
@@ -161,11 +161,9 @@ def test_upload_apk_with_whats_new(edit_service_mock, monkeypatch):
 
     for (locale, whats_new) in expected_locales:
         for version_code in range(2):
-            edit_service_mock.update_apk_listings.assert_any_call(locale, str(version_code), body={
-                'recentChanges': whats_new
-            })
+            edit_service_mock.update_whats_new.assert_any_call(locale, str(version_code), whats_new)
 
-    assert edit_service_mock.update_apk_listings.call_count == 6
+    assert edit_service_mock.update_whats_new.call_count == 6
     edit_service_mock.commit_transaction.assert_called_once_with()
 
 

--- a/mozapkpublisher/test/test_update_apk_description.py
+++ b/mozapkpublisher/test/test_update_apk_description.py
@@ -48,11 +48,12 @@ def test_update_apk_description_force_locale(monkeypatch):
     config['force_locale'] = 'en-US'
     UpdateDescriptionAPK(config).run()
 
-    edit_service_mock.update_listings.assert_called_once_with('google_play_locale', body={
-        'fullDescription': 'Long description',
-        'shortDescription': 'Short',
-        'title': 'Firefox for Android',
-    })
+    edit_service_mock.update_listings.assert_called_once_with(
+        'google_play_locale',
+        full_description='Long description',
+        short_description='Short',
+        title='Firefox for Android',
+    )
 
     assert edit_service_mock.update_listings.call_count == 1
     edit_service_mock.commit_transaction.assert_called_once_with()

--- a/mozapkpublisher/update_apk_description.py
+++ b/mozapkpublisher/update_apk_description.py
@@ -47,11 +47,12 @@ See bug https://github.com/mozilla-l10n/stores_l10n/issues/71')
         for locale in locales:
             translation = store_l10n.get_translation(release_channel, locale)
             google_play_locale = store_l10n.locale_mapping(locale)
-            edit_service.update_listings(google_play_locale, body={
-                'fullDescription': translation.get('long_desc'),
-                'shortDescription': translation.get('short_desc'),
-                'title': translation.get('title')
-            })
+            edit_service.update_listings(
+                google_play_locale,
+                full_description=translation.get('long_desc'),
+                short_description=translation.get('short_desc'),
+                title=translation.get('title'),
+            )
 
         edit_service.commit_transaction()
         logger.info('Done. {} locale(s) updated'.format(len(locales)))


### PR DESCRIPTION
The patch could have been smaller. We technically just needed to call `edit_service.update_listings()` in `_push_whats_new`. However, I wanted to be sure the data structures passed to googleplay.py were the same as in `update_apk_description.py` (that's the script I used yesterday to unlock the locales).

Hence, I first added more tests to googleplay.py to freeze the calls sent to google-api-python-client. Then, I changed the method parameters in EditService. Finally, the calls are made from push_apk.

I've been cautious because we don't have a way to manually test it, other than when it's in production.

cc @flodolo 