### PR TITLE
Python 2: Fix non-ASCII logs

### DIFF
--- a/mozapkpublisher/googleplay.py
+++ b/mozapkpublisher/googleplay.py
@@ -113,10 +113,11 @@ class EditService(object):
             'shortDescription': short_description,
             'title': title,
         }
-        self._service.listings().update(
+        response = self._service.listings().update(
             editId=self._edit_id, packageName=self._package_name, language=language, body=body
         ).execute()
-        logger.info('Listing for language "{}" has been updated with: {}'.format(language, body))
+        logger.info(u'Listing for language "{}" has been updated with: {}'.format(language, body))
+        logger.debug(u'Listing response: {}'.format(response))
 
     @transaction_required
     def update_whats_new(self, language, apk_version_code, whats_new):
@@ -124,10 +125,10 @@ class EditService(object):
             editId=self._edit_id, packageName=self._package_name, language=language,
             apkVersionCode=apk_version_code, body={'recentChanges': whats_new}
         ).execute()
-        logger.info('What\'s new listing for ("{}", "{}") has been updated to: "{}"'.format(
+        logger.info(u'What\'s new listing for ("{}", "{}") has been updated to: "{}"'.format(
             language, apk_version_code, whats_new
         ))
-        logger.debug('Listing response: {}', response)
+        logger.debug(u'Apk listing response: {}'.format(response))
 
 
 def _connect(service_account, credentials_file_path):


### PR DESCRIPTION
Fallout of #22. On python 2, this caused:

```
2017-03-28 15:15:03,300 - discovery.py - INFO - URL being requested: PUT https://www.googleapis.com/androidpublisher/v2/applications/org.mozilla.firefox/edits/12907616204018632884/apks/2015478529/listings/cs-CZ?alt=json
Traceback (most recent call last):
  File "mozapkpublisher/push_apk.py", line 131, in <module>
    main(__name__)
  File "mozapkpublisher/push_apk.py", line 124, in main
    PushAPK().run()
  File "mozapkpublisher/push_apk.py", line 80, in run
    self.upload_apks(apks)
  File "mozapkpublisher/push_apk.py", line 64, in upload_apks
    _update_or_create_all_locales(edit_service, release_channel, apk['version_code'])
  File "mozapkpublisher/push_apk.py", line 99, in _update_or_create_all_locales
    play_store_locale, apk_version_code, whats_new=translation.get('whatsnew')
  File "/home/jcristau/src/github.com/mozilla-releng/mozapkpublisher/mozapkpublisher/googleplay.py", line 68, in _transaction_required
    return method(*args, **kwargs)
  File "/home/jcristau/src/github.com/mozilla-releng/mozapkpublisher/mozapkpublisher/googleplay.py", line 128, in update_whats_new
    language, apk_version_code, whats_new
UnicodeEncodeError: 'ascii' codec can't encode character u'\u0161' in position 7: ordinal not in range(128)
```