### PR TITLE
Upload nightly strings

### DIFF
--- a/mozapkpublisher/googleplay.py
+++ b/mozapkpublisher/googleplay.py
@@ -26,7 +26,9 @@ from mozapkpublisher.exceptions import NoTransactionError, WrongArgumentGiven
 TRACK_VALUES = ('production', 'beta', 'alpha', 'rollout')
 
 PACKAGE_NAME_VALUES = {
-    'org.mozilla.fennec_aurora': 'aurora',
+    # Due to project Dawn, Nightly is now using the Aurora package name.
+    # See https://bugzilla.mozilla.org/show_bug.cgi?id=1357351
+    'org.mozilla.fennec_aurora': 'nightly',
     'org.mozilla.firefox_beta': 'beta',
     'org.mozilla.firefox': 'release'
 }

--- a/mozapkpublisher/push_apk.py
+++ b/mozapkpublisher/push_apk.py
@@ -55,17 +55,12 @@ class PushAPK(Base):
         )
         release_channel = googleplay.PACKAGE_NAME_VALUES[self.config.package_name]
 
-        if 'aurora' in self.config.package_name:
-            logger.warning('Aurora is not supported by the L10n Store (see \
-https://github.com/mozilla-l10n/stores_l10n/issues/71). Skipping what\'s new.')
-        else:
-            _create_or_update_listings(edit_service, release_channel)
+        _create_or_update_listings(edit_service, release_channel)
 
         for apk in apks.values():
             apk_response = edit_service.upload_apk(apk['file'])
             apk['version_code'] = apk_response['versionCode']
-            if 'aurora' not in self.config.package_name:
-                _create_or_update_whats_new(edit_service, release_channel, apk['version_code'])
+            _create_or_update_whats_new(edit_service, release_channel, apk['version_code'])
 
         all_version_codes = _check_and_get_flatten_version_codes(apks)
         edit_service.update_track(self.config.track, all_version_codes, self.config.rollout_percentage)

--- a/mozapkpublisher/push_apk.py
+++ b/mozapkpublisher/push_apk.py
@@ -8,6 +8,7 @@ from mozapkpublisher import googleplay, store_l10n
 from mozapkpublisher import apk as apk_helper
 from mozapkpublisher.base import Base, ArgumentParser
 from mozapkpublisher.exceptions import WrongArgumentGiven, ArmVersionCodeTooHigh
+from mozapkpublisher.update_apk_description import create_or_update_listings
 
 logger = logging.getLogger(__name__)
 
@@ -53,14 +54,12 @@ class PushAPK(Base):
             self.config.service_account, self.config.google_play_credentials_file.name, self.config.package_name,
             self.config.dry_run
         )
-        release_channel = googleplay.PACKAGE_NAME_VALUES[self.config.package_name]
-
-        _create_or_update_listings(edit_service, release_channel)
+        create_or_update_listings(edit_service, self.config.package_name)
 
         for apk in apks.values():
             apk_response = edit_service.upload_apk(apk['file'])
             apk['version_code'] = apk_response['versionCode']
-            _create_or_update_whats_new(edit_service, release_channel, apk['version_code'])
+            _create_or_update_whats_new(edit_service, self.config.package_name, apk['version_code'])
 
         all_version_codes = _check_and_get_flatten_version_codes(apks)
         edit_service.update_track(self.config.track, all_version_codes, self.config.rollout_percentage)
@@ -79,19 +78,8 @@ class PushAPK(Base):
         self.upload_apks(apks)
 
 
-def _create_or_update_listings(edit_service, release_channel):
-    locales = store_l10n.get_translations_per_google_play_locale_code(release_channel)
-
-    for google_play_locale_code, translation in locales.items():
-        edit_service.update_listings(
-            google_play_locale_code,
-            full_description=translation.get('long_desc'),
-            short_description=translation.get('short_desc'),
-            title=translation.get('title'),
-        )
-
-
-def _create_or_update_whats_new(edit_service, release_channel, apk_version_code):
+def _create_or_update_whats_new(edit_service, package_name, apk_version_code):
+    release_channel = googleplay.PACKAGE_NAME_VALUES[package_name]
     locales = store_l10n.get_translations_per_google_play_locale_code(release_channel)
 
     for google_play_locale_code, translation in locales.items():

--- a/mozapkpublisher/store_l10n.py
+++ b/mozapkpublisher/store_l10n.py
@@ -39,7 +39,18 @@ def locale_mapping(locale):
     return _mappings[locale] if locale in _mappings else locale
 
 
-def get_translations_per_google_play_locale_code(release_channel):
+def get_translations_per_google_play_locale_code(release_channel, moz_locales=None):
+    global _translations_per_google_play_locale_code
+
+    _init_full_locales_if_needed(release_channel)
+
+    return _translations_per_google_play_locale_code if moz_locales is None else {
+        locale_mapping(moz_locale): _translations_per_google_play_locale_code[locale_mapping(moz_locale)]
+        for moz_locale in moz_locales
+    }
+
+
+def _init_full_locales_if_needed(release_channel):
     global _translations_per_google_play_locale_code
 
     if _translations_per_google_play_locale_code is None:
@@ -56,5 +67,3 @@ def get_translations_per_google_play_locale_code(release_channel):
         logger.info('Locales downloaded and converted to: {}'.format(
             _translations_per_google_play_locale_code.keys()
         ))
-
-    return _translations_per_google_play_locale_code

--- a/mozapkpublisher/store_l10n.py
+++ b/mozapkpublisher/store_l10n.py
@@ -14,38 +14,16 @@ _mappings = None
 _translations_per_google_play_locale_code = None
 
 
-def get_list_locales(release_channel):
-    """ Get all the translated locales supported by Google play
-    So, locale unsupported by Google play won't be downloaded
-    Idem for not translated locale
-    """
-    return utils.load_json_url(ALL_LOCALES_URL.format(channel=release_channel))
-
-
-def get_translation(release_channel, locale):
-    """ Get the translation for a locale
-    """
-    return utils.load_json_url(LOCALE_URL.format(channel=release_channel, locale=locale))
-
-
-def locale_mapping(locale):
-    """ Google play and Mozilla don't have the exact locale code
-    Translate them
-    """
-    global _mappings
-    if _mappings is None:
-        _mappings = utils.load_json_url(MAPPING_URL)
-
-    return _mappings[locale] if locale in _mappings else locale
-
-
 def get_translations_per_google_play_locale_code(release_channel, moz_locales=None):
     global _translations_per_google_play_locale_code
 
     _init_full_locales_if_needed(release_channel)
 
     return _translations_per_google_play_locale_code if moz_locales is None else {
-        locale_mapping(moz_locale): _translations_per_google_play_locale_code[locale_mapping(moz_locale)]
+        _translate_moz_locate_into_google_play_one(moz_locale):
+        _translations_per_google_play_locale_code[
+            _translate_moz_locate_into_google_play_one(moz_locale)
+        ]
         for moz_locale in moz_locales
     }
 
@@ -54,16 +32,36 @@ def _init_full_locales_if_needed(release_channel):
     global _translations_per_google_play_locale_code
 
     if _translations_per_google_play_locale_code is None:
-        moz_locales = get_list_locales(release_channel)
+        moz_locales = _get_list_of_completed_locales(release_channel)
         moz_locales.append(u'en-US')
 
         logger.info('Downloading {} locales: {}...'.format(
             len(moz_locales), moz_locales
         ))
         _translations_per_google_play_locale_code = {
-            locale_mapping(moz_locale): get_translation(release_channel, moz_locale)
+            _translate_moz_locate_into_google_play_one(moz_locale): _get_translation(release_channel, moz_locale)
             for moz_locale in moz_locales
         }
         logger.info('Locales downloaded and converted to: {}'.format(
             _translations_per_google_play_locale_code.keys()
         ))
+
+
+def _get_list_of_completed_locales(release_channel):
+    """ Get all the translated locales supported by Google play
+    So, locale unsupported by Google play won't be downloaded
+    Idem for not translated locale
+    """
+    return utils.load_json_url(ALL_LOCALES_URL.format(channel=release_channel))
+
+
+def _get_translation(release_channel, locale):
+    return utils.load_json_url(LOCALE_URL.format(channel=release_channel, locale=locale))
+
+
+def _translate_moz_locate_into_google_play_one(locale):
+    global _mappings
+    if _mappings is None:
+        _mappings = utils.load_json_url(MAPPING_URL)
+
+    return _mappings[locale] if locale in _mappings else locale

--- a/mozapkpublisher/test/test_push_apk.py
+++ b/mozapkpublisher/test/test_push_apk.py
@@ -12,6 +12,7 @@ from tempfile import NamedTemporaryFile
 from mozapkpublisher import apk, googleplay, store_l10n
 from mozapkpublisher.exceptions import WrongArgumentGiven, ArmVersionCodeTooHigh
 from mozapkpublisher.push_apk import PushAPK, main, _check_and_get_flatten_version_codes
+from mozapkpublisher.test.test_store_l10n import set_translations_per_google_play_locale_code
 
 
 credentials = NamedTemporaryFile()
@@ -44,29 +45,6 @@ def edit_service_mock():
 
     _edit_service_mock.upload_apk.side_effect = _generate_version_code
     return _edit_service_mock
-
-
-def set_translations_per_google_play_locale_code(_monkeypatch):
-    _monkeypatch.setattr(store_l10n, '_translations_per_google_play_locale_code', {
-        'en-GB': {
-            'title': 'Firefox for Android',
-            'long_desc': 'Long description',
-            'short_desc': 'Short',
-            'whatsnew': 'Check out this cool feature!',
-        },
-        'en-US': {
-            'title': 'Firefox for Android',
-            'long_desc': 'Long description',
-            'short_desc': 'Short',
-            'whatsnew': 'Check out this cool feature!',
-        },
-        'es-US': {
-            'title': 'Navegador web Firefox',
-            'long_desc': 'Descripcion larga',
-            'short_desc': 'Corto',
-            'whatsnew': 'Mire a esta caracteristica',
-        },
-    })
 
 
 def test_one_missing_file():
@@ -170,7 +148,7 @@ def test_upload_apk_with_locales_updated(edit_service_mock, monkeypatch):
     monkeypatch.setattr(googleplay, 'EditService', lambda _, __, ___, ____: edit_service_mock)
     monkeypatch.setattr(apk, 'check_if_apk_is_multilocale', lambda _: None)
     set_translations_per_google_play_locale_code(monkeypatch)
-    monkeypatch.setattr(store_l10n, 'locale_mapping', lambda locale: 'es-US' if locale == 'es-MX' else locale)
+    monkeypatch.setattr(store_l10n, '_translate_moz_locate_into_google_play_one', lambda locale: 'es-US' if locale == 'es-MX' else locale)
 
     config = copy(VALID_CONFIG)
     config['package_name'] = 'org.mozilla.firefox_beta'

--- a/mozapkpublisher/test/test_push_apk.py
+++ b/mozapkpublisher/test/test_push_apk.py
@@ -177,7 +177,7 @@ def test_upload_apk_with_locales_updated(edit_service_mock, monkeypatch):
         for version_code in range(2):
             edit_service_mock.update_whats_new.assert_any_call(locale, str(version_code), whats_new=whats_new)
 
-    assert edit_service_mock.update_listings.call_count == 6
+    assert edit_service_mock.update_listings.call_count == 3
     assert edit_service_mock.update_whats_new.call_count == 6
     edit_service_mock.commit_transaction.assert_called_once_with()
 

--- a/mozapkpublisher/test/test_push_apk.py
+++ b/mozapkpublisher/test/test_push_apk.py
@@ -46,6 +46,29 @@ def edit_service_mock():
     return _edit_service_mock
 
 
+def set_translations_per_google_play_locale_code(_monkeypatch):
+    _monkeypatch.setattr(store_l10n, '_translations_per_google_play_locale_code', {
+        'en-GB': {
+            'title': 'Firefox for Android',
+            'long_desc': 'Long description',
+            'short_desc': 'Short',
+            'whatsnew': 'Check out this cool feature!',
+        },
+        'en-US': {
+            'title': 'Firefox for Android',
+            'long_desc': 'Long description',
+            'short_desc': 'Short',
+            'whatsnew': 'Check out this cool feature!',
+        },
+        'es-US': {
+            'title': 'Navegador web Firefox',
+            'long_desc': 'Descripcion larga',
+            'short_desc': 'Corto',
+            'whatsnew': 'Mire a esta caracteristica',
+        },
+    })
+
+
 def test_one_missing_file():
     config = copy(VALID_CONFIG)
 
@@ -98,6 +121,7 @@ def test_valid_rollout_percentage(edit_service_mock, monkeypatch):
 
     monkeypatch.setattr(googleplay, 'EditService', lambda _, __, ___, ____: edit_service_mock)
     monkeypatch.setattr(apk, 'check_if_apk_is_multilocale', lambda _: None)
+    set_translations_per_google_play_locale_code(monkeypatch)
     for i in range(0, 101):
         valid_percentage = i
         config['rollout_percentage'] = valid_percentage
@@ -131,6 +155,7 @@ def test_check_and_get_flatten_version_codes():
 def test_upload_apk(edit_service_mock, monkeypatch):
     monkeypatch.setattr(googleplay, 'EditService', lambda _, __, ___, ____: edit_service_mock)
     monkeypatch.setattr(apk, 'check_if_apk_is_multilocale', lambda _: None)
+    set_translations_per_google_play_locale_code(monkeypatch)
 
     PushAPK(VALID_CONFIG).run()
 
@@ -144,19 +169,7 @@ def test_upload_apk(edit_service_mock, monkeypatch):
 def test_upload_apk_with_locales_updated(edit_service_mock, monkeypatch):
     monkeypatch.setattr(googleplay, 'EditService', lambda _, __, ___, ____: edit_service_mock)
     monkeypatch.setattr(apk, 'check_if_apk_is_multilocale', lambda _: None)
-
-    monkeypatch.setattr(store_l10n, 'get_list_locales', lambda _: [u'en-GB', u'es-MX'])
-    monkeypatch.setattr(store_l10n, 'get_translation', lambda _, locale: {
-        'title': 'Navegador web Firefox',
-        'long_desc': 'Descripcion larga',
-        'short_desc': 'Corto',
-        'whatsnew': 'Mire a esta caracteristica',
-    } if locale == 'es-MX' else {
-        'title': 'Firefox for Android',
-        'long_desc': 'Long description',
-        'short_desc': 'Short',
-        'whatsnew': 'Check out this cool feature!',
-    })
+    set_translations_per_google_play_locale_code(monkeypatch)
     monkeypatch.setattr(store_l10n, 'locale_mapping', lambda locale: 'es-US' if locale == 'es-MX' else locale)
 
     config = copy(VALID_CONFIG)

--- a/mozapkpublisher/test/test_store_l10n.py
+++ b/mozapkpublisher/test/test_store_l10n.py
@@ -6,7 +6,8 @@ except ImportError:
 from mozapkpublisher import utils
 
 from mozapkpublisher import store_l10n
-from mozapkpublisher.store_l10n import get_list_locales, get_translation, locale_mapping
+from mozapkpublisher.store_l10n import get_translations_per_google_play_locale_code, \
+    _get_list_of_completed_locales, _get_translation, _translate_moz_locate_into_google_play_one
 
 L10N_API_URL = 'https://l10n.mozilla-community.org/stores_l10n/'
 ALL_LOCALES_URL = L10N_API_URL + 'api/v1/fx_android/listing/{channel}/'
@@ -16,13 +17,73 @@ MAPPING_URL = L10N_API_URL + 'api/v1/google/localesmapping/?reverse'
 _mappings = None
 
 
-def test_get_list_locales(monkeypatch):
+def set_translations_per_google_play_locale_code(_monkeypatch):
+    _monkeypatch.setattr(store_l10n, '_translations_per_google_play_locale_code', {
+        'en-GB': {
+            'title': 'Firefox for Android',
+            'long_desc': 'Long description',
+            'short_desc': 'Short',
+            'whatsnew': 'Check out this cool feature!',
+        },
+        'en-US': {
+            'title': 'Firefox for Android',
+            'long_desc': 'Long description',
+            'short_desc': 'Short',
+            'whatsnew': 'Check out this cool feature!',
+        },
+        'es-US': {
+            'title': 'Navegador web Firefox',
+            'long_desc': 'Descripcion larga',
+            'short_desc': 'Corto',
+            'whatsnew': 'Mire a esta caracteristica',
+        },
+    })
+
+
+def test_get_translations_per_google_play_locale_code(monkeypatch):
+    set_translations_per_google_play_locale_code(monkeypatch)
+    monkeypatch.setattr(store_l10n, '_mappings', {
+        'es-MX': 'es-US',
+    })
+
+    assert get_translations_per_google_play_locale_code('beta') == {
+        'en-GB': {
+            'title': 'Firefox for Android',
+            'long_desc': 'Long description',
+            'short_desc': 'Short',
+            'whatsnew': 'Check out this cool feature!',
+        },
+        'en-US': {
+            'title': 'Firefox for Android',
+            'long_desc': 'Long description',
+            'short_desc': 'Short',
+            'whatsnew': 'Check out this cool feature!',
+        },
+        'es-US': {
+            'title': 'Navegador web Firefox',
+            'long_desc': 'Descripcion larga',
+            'short_desc': 'Corto',
+            'whatsnew': 'Mire a esta caracteristica',
+        },
+    }
+
+    assert get_translations_per_google_play_locale_code('release', moz_locales=['es-MX']) == {
+        'es-US': {
+            'title': 'Navegador web Firefox',
+            'long_desc': 'Descripcion larga',
+            'short_desc': 'Corto',
+            'whatsnew': 'Mire a esta caracteristica',
+        },
+    }
+
+
+def test_get_list_of_completed_locales(monkeypatch):
     monkeypatch.setattr(
         utils, 'load_json_url',
         lambda url: [u'en-GB', u'es-ES']
         if url == 'https://l10n.mozilla-community.org/stores_l10n/api/v1/fx_android/listing/beta/' else None
     )
-    assert get_list_locales('beta') == [u'en-GB', u'es-ES']
+    assert _get_list_of_completed_locales('beta') == [u'en-GB', u'es-ES']
 
 
 def test_get_translation(monkeypatch):
@@ -35,7 +96,7 @@ def test_get_translation(monkeypatch):
             'whatsnew': 'Check out this cool feature!'
         } if url == 'https://l10n.mozilla-community.org/stores_l10n/api/v1/fx_android/translation/beta/en-GB/' else None
     )
-    assert get_translation('beta', 'en-GB') == {
+    assert _get_translation('beta', 'en-GB') == {
         'title': 'Firefox for Android Beta',
         'long_desc': 'Long description',
         'short_desc': 'Short',
@@ -43,7 +104,7 @@ def test_get_translation(monkeypatch):
     }
 
 
-def test_locale_mapping(monkeypatch):
+def test_translate_moz_locate_into_google_play_one(monkeypatch):
     mock_json_url = MagicMock()
     mock_json_url.side_effect = lambda url: {
         u'en-GB': u'en-GB',
@@ -53,9 +114,9 @@ def test_locale_mapping(monkeypatch):
     monkeypatch.setattr(utils, 'load_json_url', mock_json_url)
     # Makes sure the locale mappings hasn't been loaded yet
     monkeypatch.setattr(store_l10n, '_mappings', None)
-    assert locale_mapping('en-GB') == 'en-GB'
-    assert locale_mapping('es-MX') == 'es-US'
+    assert _translate_moz_locate_into_google_play_one('en-GB') == 'en-GB'
+    assert _translate_moz_locate_into_google_play_one('es-MX') == 'es-US'
 
     # Mappings should be loaded only once
     assert mock_json_url.call_count == 1
-    assert locale_mapping('non-mapped-locale') == 'non-mapped-locale'
+    assert _translate_moz_locate_into_google_play_one('non-mapped-locale') == 'non-mapped-locale'

--- a/mozapkpublisher/test/test_store_l10n.py
+++ b/mozapkpublisher/test/test_store_l10n.py
@@ -5,6 +5,7 @@ except ImportError:
 
 from mozapkpublisher import utils
 
+from mozapkpublisher import store_l10n
 from mozapkpublisher.store_l10n import get_list_locales, get_translation, locale_mapping
 
 L10N_API_URL = 'https://l10n.mozilla-community.org/stores_l10n/'
@@ -50,7 +51,11 @@ def test_locale_mapping(monkeypatch):
     } if url == 'https://l10n.mozilla-community.org/stores_l10n/api/v1/google/localesmapping/?reverse' else None
 
     monkeypatch.setattr(utils, 'load_json_url', mock_json_url)
+    # Makes sure the locale mappings hasn't been loaded yet
+    monkeypatch.setattr(store_l10n, '_mappings', None)
     assert locale_mapping('en-GB') == 'en-GB'
     assert locale_mapping('es-MX') == 'es-US'
+
+    # Mappings should be loaded only once
     assert mock_json_url.call_count == 1
     assert locale_mapping('non-mapped-locale') == 'non-mapped-locale'

--- a/mozapkpublisher/test/test_update_apk_description.py
+++ b/mozapkpublisher/test/test_update_apk_description.py
@@ -10,7 +10,6 @@ from copy import copy
 from tempfile import NamedTemporaryFile
 
 from mozapkpublisher import googleplay, store_l10n
-from mozapkpublisher.exceptions import WrongArgumentGiven
 from mozapkpublisher.update_apk_description import UpdateDescriptionAPK, main
 
 
@@ -23,25 +22,18 @@ VALID_CONFIG = {
 }
 
 
-def test_aurora_not_supported():
-    config = copy(VALID_CONFIG)
-    config['package_name'] = 'org.mozilla.fennec_aurora'
-
-    with pytest.raises(WrongArgumentGiven):
-        UpdateDescriptionAPK(config)
-
-
 def test_update_apk_description_force_locale(monkeypatch):
     edit_service_mock = create_autospec(googleplay.EditService)
     edit_service_mock.upload_apk.side_effect = [{'versionCode': str(i)} for i in range(2)]
     monkeypatch.setattr(googleplay, 'EditService', lambda _, __, ___, ____: edit_service_mock)
-
-    monkeypatch.setattr(store_l10n, 'get_translation', lambda _, locale: {
-        'title': 'Firefox for Android',
-        'long_desc': 'Long description',
-        'short_desc': 'Short',
-        'whatsnew': 'Check out this cool feature!',
-    } if locale == 'en-US' else None)
+    monkeypatch.setattr(store_l10n, '_translations_per_google_play_locale_code', {
+        'google_play_locale': {
+            'title': 'Firefox for Android',
+            'long_desc': 'Long description',
+            'short_desc': 'Short',
+            'whatsnew': 'Check out this cool feature!',
+        }
+    })
     monkeypatch.setattr(store_l10n, 'locale_mapping', lambda locale: 'google_play_locale')
 
     config = copy(VALID_CONFIG)

--- a/mozapkpublisher/test/test_update_apk_description.py
+++ b/mozapkpublisher/test/test_update_apk_description.py
@@ -34,7 +34,7 @@ def test_update_apk_description_force_locale(monkeypatch):
             'whatsnew': 'Check out this cool feature!',
         }
     })
-    monkeypatch.setattr(store_l10n, 'locale_mapping', lambda locale: 'google_play_locale')
+    monkeypatch.setattr(store_l10n, '_translate_moz_locate_into_google_play_one', lambda locale: 'google_play_locale')
 
     config = copy(VALID_CONFIG)
     config['force_locale'] = 'en-US'


### PR DESCRIPTION
This PR:

* optimize the number of requests done to store_l10n and google play
* factorize the behaviors between push_apk and update_apk_description
* shuffle store_l10n to expose only what's necessary.

I tested both `push_apk.py` and `update_apk_description.py` manually with dry-run mode

After this PR, 0.4.0 should be released

r? @sylvestre 