### PR TITLE
update_apk_description: Support Firefox Focus

### DIFF
--- a/mozapkpublisher/googleplay.py
+++ b/mozapkpublisher/googleplay.py
@@ -20,24 +20,18 @@ from oauth2client.service_account import ServiceAccountCredentials
 from apiclient.discovery import build
 
 from mozapkpublisher.exceptions import NoTransactionError, WrongArgumentGiven
+from mozapkpublisher.store_l10n import STORE_PRODUCT_DETAILS_PER_PACKAGE_NAME
 
 # Google play has currently 3 tracks. Rollout deploys
 # to a limited percentage of users
 TRACK_VALUES = ('production', 'beta', 'alpha', 'rollout')
 
-PACKAGE_NAME_VALUES = {
-    # Due to project Dawn, Nightly is now using the Aurora package name.
-    # See https://bugzilla.mozilla.org/show_bug.cgi?id=1357351
-    'org.mozilla.fennec_aurora': 'nightly',
-    'org.mozilla.firefox_beta': 'beta',
-    'org.mozilla.firefox': 'release'
-}
 
 logger = logging.getLogger(__name__)
 
 
 def add_general_google_play_arguments(parser):
-    parser.add_argument('--package-name', choices=PACKAGE_NAME_VALUES.keys(),
+    parser.add_argument('--package-name', choices=STORE_PRODUCT_DETAILS_PER_PACKAGE_NAME.keys(),
                         help='The Google play name of the app', required=True)
 
     parser.add_argument('--service-account', help='The service account email', required=True)

--- a/mozapkpublisher/push_apk.py
+++ b/mozapkpublisher/push_apk.py
@@ -79,8 +79,7 @@ class PushAPK(Base):
 
 
 def _create_or_update_whats_new(edit_service, package_name, apk_version_code):
-    release_channel = googleplay.PACKAGE_NAME_VALUES[package_name]
-    locales = store_l10n.get_translations_per_google_play_locale_code(release_channel)
+    locales = store_l10n.get_translations_per_google_play_locale_code(package_name)
 
     for google_play_locale_code, translation in locales.items():
         edit_service.update_whats_new(

--- a/mozapkpublisher/test/test_store_l10n.py
+++ b/mozapkpublisher/test/test_store_l10n.py
@@ -9,13 +9,6 @@ from mozapkpublisher import store_l10n
 from mozapkpublisher.store_l10n import get_translations_per_google_play_locale_code, \
     _get_list_of_completed_locales, _get_translation, _translate_moz_locate_into_google_play_one
 
-L10N_API_URL = 'https://l10n.mozilla-community.org/stores_l10n/'
-ALL_LOCALES_URL = L10N_API_URL + 'api/v1/fx_android/listing/{channel}/'
-LOCALE_URL = L10N_API_URL + 'api/v1/fx_android/translation/{channel}/{locale}/'
-MAPPING_URL = L10N_API_URL + 'api/v1/google/localesmapping/?reverse'
-
-_mappings = None
-
 
 def set_translations_per_google_play_locale_code(_monkeypatch):
     _monkeypatch.setattr(store_l10n, '_translations_per_google_play_locale_code', {
@@ -46,7 +39,7 @@ def test_get_translations_per_google_play_locale_code(monkeypatch):
         'es-MX': 'es-US',
     })
 
-    assert get_translations_per_google_play_locale_code('beta') == {
+    assert get_translations_per_google_play_locale_code('org.mozilla.firefox_beta') == {
         'en-GB': {
             'title': 'Firefox for Android',
             'long_desc': 'Long description',
@@ -67,7 +60,7 @@ def test_get_translations_per_google_play_locale_code(monkeypatch):
         },
     }
 
-    assert get_translations_per_google_play_locale_code('release', moz_locales=['es-MX']) == {
+    assert get_translations_per_google_play_locale_code('org.mozilla.firefox', moz_locales=['es-MX']) == {
         'es-US': {
             'title': 'Navegador web Firefox',
             'long_desc': 'Descripcion larga',
@@ -83,7 +76,7 @@ def test_get_list_of_completed_locales(monkeypatch):
         lambda url: [u'en-GB', u'es-ES']
         if url == 'https://l10n.mozilla-community.org/stores_l10n/api/v1/fx_android/listing/beta/' else None
     )
-    assert _get_list_of_completed_locales('beta') == [u'en-GB', u'es-ES']
+    assert _get_list_of_completed_locales('fx_android', 'beta') == [u'en-GB', u'es-ES']
 
 
 def test_get_translation(monkeypatch):
@@ -96,7 +89,7 @@ def test_get_translation(monkeypatch):
             'whatsnew': 'Check out this cool feature!'
         } if url == 'https://l10n.mozilla-community.org/stores_l10n/api/v1/fx_android/translation/beta/en-GB/' else None
     )
-    assert _get_translation('beta', 'en-GB') == {
+    assert _get_translation('fx_android', 'beta', 'en-GB') == {
         'title': 'Firefox for Android Beta',
         'long_desc': 'Long description',
         'short_desc': 'Short',

--- a/mozapkpublisher/update_apk_description.py
+++ b/mozapkpublisher/update_apk_description.py
@@ -43,8 +43,7 @@ class UpdateDescriptionAPK(Base):
 
 
 def create_or_update_listings(edit_service, package_name, moz_locales=None):
-    release_channel = googleplay.PACKAGE_NAME_VALUES[package_name]
-    locales = store_l10n.get_translations_per_google_play_locale_code(release_channel, moz_locales)
+    locales = store_l10n.get_translations_per_google_play_locale_code(package_name, moz_locales)
 
     for google_play_locale_code, translation in locales.items():
         edit_service.update_listings(


### PR DESCRIPTION
I couldn't not fully test against `org.mozilla.focus` because:

a. I don't have the rights to modify this app
b. No APK has been uploaded yet. Hence Google Play returns: `No application was found for the given package name.`

The package name was taken from https://github.com/mozilla-mobile/focus-android/blob/09784e886254ae6a398b7156930ebd7efeb2dd91/app/src/main/java/org/mozilla/focus/FocusApplication.java#L6 