### PR TITLE
Add check to verify APK architecures

### DIFF
--- a/mozapkpublisher/apk.py
+++ b/mozapkpublisher/apk.py
@@ -4,13 +4,21 @@ import re
 from io import BytesIO
 from zipfile import ZipFile
 
-from mozapkpublisher.exceptions import NoLocaleFound, NotMultiLocaleApk
+from mozapkpublisher.exceptions import NoLocaleFound, NotMultiLocaleApk, BadApk
+from mozapkpublisher.utils import filter_out_identical_values
 
 logger = logging.getLogger(__name__)
 
 _LOCALE_LINE_PATTERN = re.compile(r'^locale \S+ (\S+) .+')
 _OMNI_JA_LOCATION = 'assets/omni.ja'
 _CHROME_MANIFEST_LOCATION = 'chrome/chrome.manifest'
+
+_CLAIMED_ARCHITECTURE_PER_DIRECTORY_NAME = {
+    'armeabi-v7a': 'armv7_v15',
+    'x86': 'x86',
+}
+_DIRECTORY_WITH_ARCHITECTURE_METADATA = 'lib/'     # For instance: lib/x86/ or lib/armeabi-v7a/
+_ARCHITECTURE_SUBDIRECTORY_INDEX = len(_DIRECTORY_WITH_ARCHITECTURE_METADATA.split('/')) - 1    # Removes last trailing slash
 
 
 def check_if_apk_is_multilocale(apk_path):
@@ -39,3 +47,53 @@ def _get_unique_locales(manifest_raw_lines):
     ]
 
     return list(set(locales))
+
+
+def check_if_apk_has_claimed_architecture(apk_path, architecture_name):
+    architecture_within_apk = get_apk_architecture(apk_path)
+
+    try:
+        pretty_architecture_within_apk = _CLAIMED_ARCHITECTURE_PER_DIRECTORY_NAME[architecture_within_apk]
+    except KeyError:
+        raise BadApk('Architecture "{}" detected within APK, but it is not supported. Supported ones are: {}'.format(
+            architecture_within_apk, _CLAIMED_ARCHITECTURE_PER_DIRECTORY_NAME.values()
+        ))
+
+    if pretty_architecture_within_apk != architecture_name:
+        raise BadApk('"{}" is not built for the architecture called "{}". Detected architecture: {}'.format(
+            apk_path, architecture_name, pretty_architecture_within_apk
+        ))
+
+    logger.info('"{}" is effectively built for architecture "{}"'.format(apk_path, architecture_name))
+
+
+def get_apk_architecture(apk_path):
+    with ZipFile(apk_path) as apk_zip:
+        files_with_architecture_in_path = [
+            file_info.filename for file_info in apk_zip.infolist()
+            if _DIRECTORY_WITH_ARCHITECTURE_METADATA in file_info.filename
+        ]
+
+    if not files_with_architecture_in_path:
+        raise BadApk('"{}" does not contain a directory called "{}"'
+                     .format(apk_path, _DIRECTORY_WITH_ARCHITECTURE_METADATA))
+
+    return _extract_architecture_from_paths(apk_path, files_with_architecture_in_path)
+
+
+def _extract_architecture_from_paths(apk_path, paths):
+    detected_architectures = [
+        path.split('/')[_ARCHITECTURE_SUBDIRECTORY_INDEX] for path in paths
+    ]
+    unique_architectures = filter_out_identical_values(detected_architectures)
+    non_empty_unique_architectures = [
+        architecture for architecture in unique_architectures if architecture
+    ]
+    number_of_unique_architectures = len(non_empty_unique_architectures)
+
+    if number_of_unique_architectures == 0:
+        raise BadApk('"{}" does not contain any architecture data under these paths: {}'.format(apk_path, paths))
+    elif number_of_unique_architectures > 1:
+        raise BadApk('"{}" contains too many architures: {}'.format(apk_path, unique_architectures))
+
+    return unique_architectures[0]

--- a/mozapkpublisher/exceptions.py
+++ b/mozapkpublisher/exceptions.py
@@ -42,6 +42,10 @@ class NoLocaleFound(LoggedError):
         )
 
 
+class BadApk(LoggedError):
+    pass
+
+
 class ArmVersionCodeTooHigh(LoggedError):
     def __init__(self, arm_version_code, x86_version_code):
         super(ArmVersionCodeTooHigh, self).__init__(

--- a/mozapkpublisher/push_apk.py
+++ b/mozapkpublisher/push_apk.py
@@ -48,7 +48,9 @@ class PushAPK(Base):
                                 help='The path to the ARM v7 API v15 APK file', required=True)
 
     def upload_apks(self, apks):
-        [apk_helper.check_if_apk_is_multilocale(apk['file']) for apk in apks.values()]
+        for architecture, apk in apks.items():
+            apk_helper.check_if_apk_has_claimed_architecture(apk['file'], architecture)
+            apk_helper.check_if_apk_is_multilocale(apk['file'])
 
         edit_service = googleplay.EditService(
             self.config.service_account, self.config.google_play_credentials_file.name, self.config.package_name,

--- a/mozapkpublisher/test/test_apk.py
+++ b/mozapkpublisher/test/test_apk.py
@@ -5,8 +5,10 @@ from shutil import rmtree
 from tempfile import mkdtemp, NamedTemporaryFile
 from zipfile import ZipFile
 
-from mozapkpublisher.apk import check_if_apk_is_multilocale, _get_unique_locales
-from mozapkpublisher.exceptions import NoLocaleFound, NotMultiLocaleApk
+from mozapkpublisher import apk
+from mozapkpublisher.apk import check_if_apk_is_multilocale, _get_unique_locales, check_if_apk_has_claimed_architecture, \
+    get_apk_architecture, _extract_architecture_from_paths
+from mozapkpublisher.exceptions import NoLocaleFound, NotMultiLocaleApk, BadApk
 
 
 MANIFEST_PARTIAL_CONTENT = '''
@@ -23,7 +25,7 @@ override chrome://global/locale/about.dtd chrome://browser/locale/overrides/abou
 '''
 
 
-def _create_apk(temp_dir, manifest_content):
+def _create_apk_with_locale_content(temp_dir, manifest_content):
     with NamedTemporaryFile('w') as manifest:
         manifest.write(manifest_content)
         manifest.seek(0)
@@ -39,15 +41,28 @@ def _create_apk(temp_dir, manifest_content):
     return apk_path
 
 
+def _create_apk_with_architecture_content(temp_dir, architecture=None):
+    random_file_in_lib = os.path.join(temp_dir, 'libmozglue.so')
+    with open(random_file_in_lib, 'w'):
+        pass
+
+    apk_path = os.path.join(temp_dir, 'fennec-{}.apk'.format(architecture))
+    with ZipFile(apk_path, 'w') as apk:
+        if architecture is not None:
+            apk.write(random_file_in_lib, 'lib/{}/libmozglue.so'.format(architecture))
+
+    return apk_path
+
+
 def test_check_if_apk_is_multilocale():
     temp_dir = mkdtemp()
-    check_if_apk_is_multilocale(_create_apk(temp_dir, MANIFEST_PARTIAL_CONTENT))
+    check_if_apk_is_multilocale(_create_apk_with_locale_content(temp_dir, MANIFEST_PARTIAL_CONTENT))
 
     with pytest.raises(NoLocaleFound):
-        check_if_apk_is_multilocale(_create_apk(temp_dir, 'non-locale stuff'))
+        check_if_apk_is_multilocale(_create_apk_with_locale_content(temp_dir, 'non-locale stuff'))
 
     with pytest.raises(NotMultiLocaleApk):
-        check_if_apk_is_multilocale(_create_apk(temp_dir, '''
+        check_if_apk_is_multilocale(_create_apk_with_locale_content(temp_dir, '''
 locale alerts en-US en-US/locale/en-US/alerts/
 locale autoconfig en-US en-US/locale/en-US/autoconfig/
 '''))
@@ -59,3 +74,43 @@ def test_get_unique_locales():
     manifest_raw_lines = MANIFEST_PARTIAL_CONTENT.split('\n')
     manifest_raw_lines = [line.encode() for line in manifest_raw_lines]
     assert sorted(_get_unique_locales(manifest_raw_lines)) == ['an', 'as', 'bn-IN', 'en-GB', 'en-US']
+
+
+def test_check_if_apk_has_claimed_architecture(monkeypatch):
+    monkeypatch.setattr(apk, 'get_apk_architecture', lambda _: 'x86')
+
+    check_if_apk_has_claimed_architecture('some.apk', 'x86')
+
+    with pytest.raises(BadApk):
+        check_if_apk_has_claimed_architecture('some.apk', 'armv7_v15')
+
+    with pytest.raises(BadApk):
+        monkeypatch.setattr(apk, 'get_apk_architecture', lambda _: 'unsupported-arch')
+        check_if_apk_has_claimed_architecture('some.apk', 'x86')
+
+
+def test_get_apk_architecture():
+    temp_dir = mkdtemp()
+
+    assert get_apk_architecture(_create_apk_with_architecture_content(temp_dir, 'x86')) == 'x86'
+    assert get_apk_architecture(_create_apk_with_architecture_content(temp_dir, 'armeabi-v7a')) == 'armeabi-v7a'
+
+    with pytest.raises(BadApk):
+        get_apk_architecture(_create_apk_with_architecture_content(temp_dir, architecture=None))
+
+    rmtree(temp_dir)
+
+
+def test_extract_architecture_from_paths():
+    assert _extract_architecture_from_paths(
+        '/path/to/apk', ['lib/armeabi-v7a/libmozglue.so', 'lib/armeabi-v7a/libplugin-container.so']
+    ) == 'armeabi-v7a'
+    assert _extract_architecture_from_paths(
+        '/path/to/apk', ['lib/x86/libmozglue.so', 'lib/x86/libplugin-container.so']
+    ) == 'x86'
+
+    with pytest.raises(BadApk):
+        _extract_architecture_from_paths('/path/to/apk', ['lib/'])
+
+    with pytest.raises(BadApk):
+        _extract_architecture_from_paths('/path/to/apk', ['lib/armeabi-v7a/libmozglue.so', 'lib/x86/libmozglue.so'])

--- a/mozapkpublisher/test/test_push_apk.py
+++ b/mozapkpublisher/test/test_push_apk.py
@@ -99,6 +99,7 @@ def test_valid_rollout_percentage(edit_service_mock, monkeypatch):
 
     monkeypatch.setattr(googleplay, 'EditService', lambda _, __, ___, ____: edit_service_mock)
     monkeypatch.setattr(apk, 'check_if_apk_is_multilocale', lambda _: None)
+    monkeypatch.setattr(apk, 'check_if_apk_has_claimed_architecture', lambda _, __: None)
     set_translations_per_google_play_locale_code(monkeypatch)
     for i in range(0, 101):
         valid_percentage = i
@@ -133,6 +134,7 @@ def test_check_and_get_flatten_version_codes():
 def test_upload_apk(edit_service_mock, monkeypatch):
     monkeypatch.setattr(googleplay, 'EditService', lambda _, __, ___, ____: edit_service_mock)
     monkeypatch.setattr(apk, 'check_if_apk_is_multilocale', lambda _: None)
+    monkeypatch.setattr(apk, 'check_if_apk_has_claimed_architecture', lambda _, __: None)
     set_translations_per_google_play_locale_code(monkeypatch)
 
     PushAPK(VALID_CONFIG).run()
@@ -147,6 +149,7 @@ def test_upload_apk(edit_service_mock, monkeypatch):
 def test_upload_apk_with_locales_updated(edit_service_mock, monkeypatch):
     monkeypatch.setattr(googleplay, 'EditService', lambda _, __, ___, ____: edit_service_mock)
     monkeypatch.setattr(apk, 'check_if_apk_is_multilocale', lambda _: None)
+    monkeypatch.setattr(apk, 'check_if_apk_has_claimed_architecture', lambda _, __: None)
     set_translations_per_google_play_locale_code(monkeypatch)
     monkeypatch.setattr(store_l10n, '_translate_moz_locate_into_google_play_one', lambda locale: 'es-US' if locale == 'es-MX' else locale)
 

--- a/mozapkpublisher/utils.py
+++ b/mozapkpublisher/utils.py
@@ -25,3 +25,7 @@ def file_sha512sum(file_path):
             hasher.update(buf)
             buf = fh.read(bs)
     return hasher.hexdigest()
+
+
+def filter_out_identical_values(list_):
+    return list(set(list_))


### PR DESCRIPTION
With [aarch64 being around](https://bugzilla.mozilla.org/show_bug.cgi?id=1368484), let's make sure we don't mix up architectures. Somebody might do the mistake, manually.

I mainly moved the lines added in https://github.com/mozilla-releng/pushapkscript/pull/15 to mozapkpublisher. 