### PR TITLE
 push_apk.py: Pass listings/whatsnew via on-disk files 

### DIFF
--- a/mozapkpublisher/googleplay.py
+++ b/mozapkpublisher/googleplay.py
@@ -36,7 +36,7 @@ def add_general_google_play_arguments(parser):
 
     parser.add_argument('--service-account', help='The service account email', required=True)
     parser.add_argument('--credentials', dest='google_play_credentials_file', type=argparse.FileType(mode='rb'),
-                        default='key.p12', help='The p12 authentication file')
+                        default='key.p12', help='The p12 authentication file', required=True)
 
     parser.add_argument('--dry-run', action='store_true',
                         help='''Perform every operation of the transation, except committing. No data will be

--- a/mozapkpublisher/test/test_store_l10n.py
+++ b/mozapkpublisher/test/test_store_l10n.py
@@ -9,28 +9,30 @@ from mozapkpublisher import store_l10n
 from mozapkpublisher.store_l10n import get_translations_per_google_play_locale_code, \
     _get_list_of_completed_locales, _get_translation, _translate_moz_locate_into_google_play_one
 
+DUMMY_TRANSLATIONS_PER_GOOGLE_PLAY_LOCALE = {
+    'en-GB': {
+        'title': 'Firefox for Android',
+        'long_desc': 'Long description',
+        'short_desc': 'Short',
+        'whatsnew': 'Check out this cool feature!',
+    },
+    'en-US': {
+        'title': 'Firefox for Android',
+        'long_desc': 'Long description',
+        'short_desc': 'Short',
+        'whatsnew': 'Check out this cool feature!',
+    },
+    'es-US': {
+        'title': 'Navegador web Firefox',
+        'long_desc': 'Descripcion larga',
+        'short_desc': 'Corto',
+        'whatsnew': 'Mire a esta caracteristica',
+    },
+}
+
 
 def set_translations_per_google_play_locale_code(_monkeypatch):
-    _monkeypatch.setattr(store_l10n, '_translations_per_google_play_locale_code', {
-        'en-GB': {
-            'title': 'Firefox for Android',
-            'long_desc': 'Long description',
-            'short_desc': 'Short',
-            'whatsnew': 'Check out this cool feature!',
-        },
-        'en-US': {
-            'title': 'Firefox for Android',
-            'long_desc': 'Long description',
-            'short_desc': 'Short',
-            'whatsnew': 'Check out this cool feature!',
-        },
-        'es-US': {
-            'title': 'Navegador web Firefox',
-            'long_desc': 'Descripcion larga',
-            'short_desc': 'Corto',
-            'whatsnew': 'Mire a esta caracteristica',
-        },
-    })
+    _monkeypatch.setattr(store_l10n, '_translations_per_google_play_locale_code', DUMMY_TRANSLATIONS_PER_GOOGLE_PLAY_LOCALE)
 
 
 def test_get_translations_per_google_play_locale_code(monkeypatch):

--- a/mozapkpublisher/update_apk_description.py
+++ b/mozapkpublisher/update_apk_description.py
@@ -35,24 +35,23 @@ class UpdateDescriptionAPK(Base):
         )
 
         moz_locales = [self.config.force_locale] if self.config.force_locale else None
-        create_or_update_listings(edit_service, self.config.package_name, moz_locales)
+        l10n_strings = store_l10n.get_translations_per_google_play_locale_code(package_name, moz_locales)
+        create_or_update_listings(edit_service, self.config.package_name, l10n_strings, moz_locales)
         edit_service.commit_transaction()
 
     def run(self):
         self.update_apk_description(self.config.package_name)
 
 
-def create_or_update_listings(edit_service, package_name, moz_locales=None):
-    locales = store_l10n.get_translations_per_google_play_locale_code(package_name, moz_locales)
-
-    for google_play_locale_code, translation in locales.items():
+def create_or_update_listings(edit_service, package_name, l10n_strings, moz_locales=None):
+    for google_play_locale_code, translation in l10n_strings.items():
         edit_service.update_listings(
             google_play_locale_code,
             full_description=translation.get('long_desc'),
             short_description=translation.get('short_desc'),
             title=translation.get('title'),
         )
-    logger.info('Listing updated for {} locale(s)'.format(len(locales)))
+    logger.info('Listing updated for {} locale(s)'.format(len(l10n_strings)))
 
 
 def main(name=None):


### PR DESCRIPTION
Fixes #37. Depends on #40. 

The content of the file isn't checked yet. I plan to do so in a follow up patch.