### PR TITLE
Drop Python 2 support 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@ sudo: false
 
 language: python
 python:
+  - "3.6"
   - "3.5"
-  - "2.7"
 
 env:
  - SKIP_NETWORK_TESTS=0
@@ -14,4 +14,4 @@ script:
     - TOX_ENVIRONMENT="py${TRAVIS_PYTHON_VERSION//./}"
     - tox -e "$TOX_ENVIRONMENT"
 after_success:
-    - if [[ $TOX_ENVIRONMENT == 'py27' ]] ; then tox -e py27-coveralls; else echo "No coverage to do"; fi
+    - if [[ $TOX_ENVIRONMENT == 'py36' ]] ; then tox -e py36-coveralls; else echo "No coverage to do"; fi

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ Scripts to publish Firefox for Android on Google Play Store.
 
 ## Setup and run
 
+1. :warning: You need Python >= 3.5 to run these set of scripts. Python 2 isn't supported starting version 0.5.0
 1. Create a virtualenv and source it
 ```sh
 virtualenv venv

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Scripts to publish Firefox for Android on Google Play Store.
 
 ## Setup and run
 
-1. :warning: You need Python >= 3.5 to run these set of scripts. Python 2 isn't supported starting version 0.5.0
+1. :warning: You need Python >= 3.5 to run this set of scripts. Python 2 isn't supported starting version 0.5.0
 1. Create a virtualenv and source it
 ```sh
 virtualenv venv

--- a/mozapkpublisher/get_apk.py
+++ b/mozapkpublisher/get_apk.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys
 import os

--- a/mozapkpublisher/get_l10n_strings.py
+++ b/mozapkpublisher/get_l10n_strings.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import argparse
 import json

--- a/mozapkpublisher/push_apk.py
+++ b/mozapkpublisher/push_apk.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import argparse
 import json

--- a/mozapkpublisher/test/common/test_googleplay.py
+++ b/mozapkpublisher/test/common/test_googleplay.py
@@ -3,10 +3,7 @@ import pytest
 import random
 import tempfile
 
-try:
-    from unittest.mock import MagicMock
-except ImportError:
-    from mock import MagicMock
+from unittest.mock import MagicMock
 
 from mozapkpublisher.common.exceptions import NoTransactionError, WrongArgumentGiven
 from mozapkpublisher.common.googleplay import add_general_google_play_arguments, EditService, is_package_name_nightly

--- a/mozapkpublisher/test/common/test_store_l10n.py
+++ b/mozapkpublisher/test/common/test_store_l10n.py
@@ -1,7 +1,4 @@
-try:
-    from unittest.mock import MagicMock
-except ImportError:
-    from mock import MagicMock
+from unittest.mock import MagicMock
 
 from mozapkpublisher.common import store_l10n, utils
 from mozapkpublisher.common.store_l10n import get_translations_per_google_play_locale_code, \

--- a/mozapkpublisher/test/common/test_utils.py
+++ b/mozapkpublisher/test/common/test_utils.py
@@ -2,10 +2,7 @@ import requests
 import requests_mock
 import tempfile
 
-try:
-    from unittest.mock import MagicMock
-except ImportError:
-    from mock import MagicMock
+from unittest.mock import MagicMock
 
 from mozapkpublisher.common.utils import load_json_url, file_sha512sum, download_file
 

--- a/mozapkpublisher/test/integration/test_get_l10n_strings.py
+++ b/mozapkpublisher/test/integration/test_get_l10n_strings.py
@@ -12,7 +12,7 @@ from mozapkpublisher.common.store_l10n import STORE_PRODUCT_DETAILS_PER_PACKAGE_
 @pytest.mark.skipif(strtobool(os.environ.get('SKIP_NETWORK_TESTS', 'true')), reason='Tests requiring network are skipped')
 @pytest.mark.parametrize('package_name', STORE_PRODUCT_DETAILS_PER_PACKAGE_NAME.keys())
 def test_download_files(package_name):
-    with tempfile.NamedTemporaryFile('w+t') as f:
+    with tempfile.NamedTemporaryFile('w+t', encoding='utf-8') as f:
         config = {
             'package_name': package_name,
             'output_file': f.name,

--- a/mozapkpublisher/test/integration/test_get_l10n_strings.py
+++ b/mozapkpublisher/test/integration/test_get_l10n_strings.py
@@ -12,7 +12,7 @@ from mozapkpublisher.common.store_l10n import STORE_PRODUCT_DETAILS_PER_PACKAGE_
 @pytest.mark.skipif(strtobool(os.environ.get('SKIP_NETWORK_TESTS', 'true')), reason='Tests requiring network are skipped')
 @pytest.mark.parametrize('package_name', STORE_PRODUCT_DETAILS_PER_PACKAGE_NAME.keys())
 def test_download_files(package_name):
-    with tempfile.NamedTemporaryFile() as f:
+    with tempfile.NamedTemporaryFile('w+t') as f:
         config = {
             'package_name': package_name,
             'output_file': f.name,
@@ -20,6 +20,5 @@ def test_download_files(package_name):
         GetL10nStrings(config).run()
 
         f.seek(0)
-        # XXX The saved JSON files contain non-latin characters. We should first convert the encoding to make sure it's a JSON file
-        json.loads(f.read().decode('utf-8'))
+        json.load(f)
         # TODO assert content is correct

--- a/mozapkpublisher/test/test_push_apk.py
+++ b/mozapkpublisher/test/test_push_apk.py
@@ -2,10 +2,7 @@ import json
 import pytest
 import sys
 
-try:
-    from unittest.mock import create_autospec
-except ImportError:
-    from mock import create_autospec
+from unittest.mock import create_autospec
 
 from copy import copy
 from tempfile import NamedTemporaryFile

--- a/mozapkpublisher/test/test_update_apk_description.py
+++ b/mozapkpublisher/test/test_update_apk_description.py
@@ -1,10 +1,7 @@
 import pytest
 import sys
 
-try:
-    from unittest.mock import create_autospec
-except ImportError:
-    from mock import create_autospec
+from unittest.mock import create_autospec
 
 from copy import copy
 from tempfile import NamedTemporaryFile

--- a/mozapkpublisher/update_apk_description.py
+++ b/mozapkpublisher/update_apk_description.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import argparse
 import logging

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,6 @@ setup(
     install_requires=requirements,
     classifiers=(
         'Development Status :: 3 - Alpha',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
     ),
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py3
+envlist = py35, py36
 
 [testenv]
 setenv =
@@ -25,7 +25,7 @@ commands=
     coverage html
     flake8
 
-[testenv:py27-coveralls]
+[testenv:py36-coveralls]
 deps=
     python-coveralls
     coverage>=4.2b1


### PR DESCRIPTION
Depends on #44

Keeping the Python 2 support is risky because of UTF-8 strings provided by https://l10n.mozilla-community.org/stores_l10n/.

This hasn't been a big issue until #41. Before then, @jcristau noted that non-ASCII languages didn't display properly, but they've been uploaded correctly.

#41 now reads UTF-8 strings from a JSON file. This requires some decoding, just like in  https://github.com/mozilla-releng/mozapkpublisher/pull/44/commits/f430c6d056e5323fd1fba75dbc53c09c6f77a63a#diff-7c3a9f88ff9e7a9a229e7fdda8bfe7a6R24. Sadly, decoding UTF-8 value back to ASCII doesn't preserve the UTF-8 characters.

Then, we should stop supporting Python 2, and make explicit that people need Python 3. Otherwise, somebody may end up uploading broken strings to Google Play.

