### PR TITLE
 Enforce incoming locales to comply to a given schema 

### DIFF
--- a/mozapkpublisher/common/exceptions.py
+++ b/mozapkpublisher/common/exceptions.py
@@ -52,3 +52,17 @@ class ArmVersionCodeTooHigh(LoggedError):
             'ARM build has a higher version code ({}) than the x86 one ({}). For more context about this error,\
 see: https://bugzilla.mozilla.org/show_bug.cgi?id=1338477'.format(arm_version_code, x86_version_code)
         )
+
+
+class NoTranslationGiven(LoggedError):
+    def __init__(self, given_translations):
+        super(NoTranslationGiven, self).__init__(
+            msg='"{}" doesn\'t contain any item to work with'.format(given_translations)
+        )
+
+
+class TranslationMissingData(LoggedError):
+    def __init__(self, locale_name, additional_message):
+        super(TranslationMissingData, self).__init__(
+            msg='Locale "{}" misses some data: {}'.format(locale_name, additional_message)
+        )

--- a/mozapkpublisher/push_apk.py
+++ b/mozapkpublisher/push_apk.py
@@ -97,6 +97,7 @@ class PushAPK(Base):
 
         if self.config.google_play_strings_file:
             l10n_strings = json.load(self.config.google_play_strings_file)
+            store_l10n.check_translations_schema(l10n_strings)
             logger.info('Loaded listings and what\'s new section from "{}"'.format(self.config.google_play_strings_file.name))
         elif self.config.update_google_play_strings_from_store:
             logger.info("Downloading listings and what's new section from L10n Store...")

--- a/mozapkpublisher/test/integration/test_get_l10n_strings.py
+++ b/mozapkpublisher/test/integration/test_get_l10n_strings.py
@@ -6,7 +6,7 @@ import tempfile
 from distutils.util import strtobool
 
 from mozapkpublisher.get_l10n_strings import GetL10nStrings
-from mozapkpublisher.common.store_l10n import STORE_PRODUCT_DETAILS_PER_PACKAGE_NAME
+from mozapkpublisher.common.store_l10n import STORE_PRODUCT_DETAILS_PER_PACKAGE_NAME, check_translations_schema
 
 
 @pytest.mark.skipif(strtobool(os.environ.get('SKIP_NETWORK_TESTS', 'true')), reason='Tests requiring network are skipped')
@@ -20,5 +20,6 @@ def test_download_files(package_name):
         GetL10nStrings(config).run()
 
         f.seek(0)
-        json.load(f)
-        # TODO assert content is correct
+        data = json.load(f)
+        # In reality, this call is already done by GetL10nStrings, but better safe than sorry
+        check_translations_schema(data)

--- a/mozapkpublisher/update_apk_description.py
+++ b/mozapkpublisher/update_apk_description.py
@@ -44,9 +44,9 @@ def create_or_update_listings(edit_service, package_name, l10n_strings, moz_loca
     for google_play_locale_code, translation in l10n_strings.items():
         edit_service.update_listings(
             google_play_locale_code,
-            full_description=translation.get('long_desc'),
-            short_description=translation.get('short_desc'),
-            title=translation.get('title'),
+            full_description=translation['long_desc'],
+            short_description=translation['short_desc'],
+            title=translation['title'],
         )
     logger.info('Listing updated for {} locale(s)'.format(len(l10n_strings)))
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,3 +2,4 @@ google-api-python-client
 oauth2client
 pyOpenSSL
 requests
+voluptuous


### PR DESCRIPTION
Depends on #45. Follow up of #41.

Let's make sure the strings coming from either https://l10n.mozilla-community.org/stores_l10n/ or a file are well-formated.