### PR TITLE
Closes #53 - Remove unneeded check for distinct package names.

### DIFF
--- a/mozapkpublisher/common/apk/checker.py
+++ b/mozapkpublisher/common/apk/checker.py
@@ -75,7 +75,6 @@ def cross_check_fennec_apks(apks_metadata_per_paths):
 
 
 def cross_check_focus_apks(apks_metadata_per_paths):
-    _check_piece_of_metadata_is_distinct('package_name', 'Package name', apks_metadata_per_paths)
     _check_number_of_distinct_packages(apks_metadata_per_paths, 2)
     _check_correct_apk_product_types(apks_metadata_per_paths, [PRODUCT.FOCUS, PRODUCT.KLAR])
     logger.info('APKs are sane!')
@@ -94,18 +93,6 @@ def _check_correct_apk_product_types(apks_metadata_per_paths, product_types):
     if not types.issubset(product_types):
         raise BadSetOfApks('Expected product types {}, found {}'.format(product_types, types))
     logger.info('Expected product types {} found'.format(product_types))
-
-
-def _check_piece_of_metadata_is_distinct(key, pretty_key, apks_metadata_per_paths):
-    all_items = [metadata[key] for metadata in apks_metadata_per_paths.values()]
-    unique_items = filter_out_identical_values(all_items)
-
-    if not unique_items:
-        raise BadSetOfApks('No {} found'.format(key))
-    if len(unique_items) != len(all_items):
-        raise BadSetOfApks("APKs share {}. Only found: {}".format(pretty_key, unique_items))
-
-    logger.info('All APKs have distinct {}: {}'.format(pretty_key, unique_items))
 
 
 def _check_piece_of_metadata_is_unique(key, pretty_key, apks_metadata_per_paths):

--- a/mozapkpublisher/test/common/apk/test_checker.py
+++ b/mozapkpublisher/test/common/apk/test_checker.py
@@ -2,7 +2,7 @@ import pytest
 
 from mozapkpublisher.common.apk.checker import cross_check_apks, \
     _check_number_of_distinct_packages, _check_correct_apk_product_types, \
-    _check_piece_of_metadata_is_distinct, _check_all_apks_have_the_same_package_name, \
+    _check_all_apks_have_the_same_package_name, \
     _check_all_apks_have_the_same_version, _check_version_matches_package_name, \
     _check_all_apks_have_the_same_build_id, _check_all_apks_have_the_same_locales, \
     _check_piece_of_metadata_is_unique, _check_apks_version_codes_are_correctly_ordered, \
@@ -233,27 +233,6 @@ def test_check_piece_of_metadata_is_unique():
             'some_key': 'some unique value',
         },
     })
-
-
-def test_check_piece_of_metadata_is_distinct():
-    _check_piece_of_metadata_is_distinct('some_key', 'Some Key', {
-        'irrelevant_key': {
-            'some_key': 'some value 1',
-        },
-        'another_irrelevant_key': {
-            'some_key': 'some value 2',
-        },
-    })
-
-    with pytest.raises(BadSetOfApks):
-        _check_piece_of_metadata_is_distinct('some_key', 'Some Key', {
-                'irrelevant_key': {
-                    'some_key': 'some value 1',
-                },
-                'another_irrelevant_key': {
-                    'some_key': 'some value 1',
-                },
-            })
 
 
 @pytest.mark.parametrize('apks_metadata_per_paths', ({


### PR DESCRIPTION
Removing the check because it's overly specific now, and redundant because we check for max number of package names.