### PR TITLE
Add a script to check whether a release stays on staged rollout for t…

### DIFF
--- a/mozapkpublisher/check_rollout.py
+++ b/mozapkpublisher/check_rollout.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+
+import argparse
+import calendar
+import email.utils as eu
+import logging
+import time
+
+import requests
+
+from mozapkpublisher.common import googleplay
+
+DAY = 24 * 60 * 60
+
+logger = logging.getLogger(__name__)
+
+
+def check_rollout(edits_service, package_name, days):
+    """Check if package_name has a release on staged rollout for too long"""
+    edit = edits_service.insert(body={}, packageName=package_name).execute()
+    response = edits_service.tracks().get(editId=edit['id'], track='production', packageName=package_name).execute()
+    releases = response['releases']
+    for release in releases:
+        if release['status'] == 'inProgress':
+            url = 'https://archive.mozilla.org/pub/mobile/releases/{}/SHA512SUMS'.format(release['name'])
+            resp = requests.head(url)
+            if resp.status_code != 200:
+                if resp.status_code != 404:  # 404 is expected for release candidates
+                    logger.warning("Could not check %s: %s", url, resp.status_code)
+                continue
+            age = time.time() - calendar.timegm(eu.parsedate(resp.headers['Last-Modified']))
+            if age >= days * DAY:
+                yield release, age
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Check for in-progress Firefox for Android staged rollout')
+    parser.add_argument('service_account', help='The service account email')
+    parser.add_argument('credentials', help='The p12 authentication file', type=argparse.FileType(mode='rb'))
+    parser.add_argument('--days', help='The time before we warn about incomplete staged rollout of a release (default: 7)',
+                        type=int, default=7)
+    config = parser.parse_args()
+
+    # TODO: use googleplay.EditService when that is ported to v3
+    service = googleplay.connect(config.service_account, config.credentials.name, 'v3').edits()
+    for (release, age) in check_rollout(service, 'org.mozilla.firefox', config.days):
+        print('fennec {} is on staged rollout at {}% but it shipped {} days ago'.format(
+              release['name'], int(release['userFraction'] * 100), int(age / DAY)))
+
+
+if __name__ == '__main__':
+    main()

--- a/mozapkpublisher/common/googleplay.py
+++ b/mozapkpublisher/common/googleplay.py
@@ -67,7 +67,7 @@ class EditService(object):
     def __init__(self, service_account, credentials_file_path, package_name, commit=False, contact_google_play=True):
         self._contact_google_play = contact_google_play
         if self._contact_google_play:
-            general_service = _connect(service_account, credentials_file_path)
+            general_service = connect(service_account, credentials_file_path)
             self._service = general_service.edits()
         else:
             self._service = _craft_google_play_service_mock()
@@ -180,7 +180,7 @@ class _ExecuteDummy():
         return self._return_value
 
 
-def _connect(service_account, credentials_file_path):
+def connect(service_account, credentials_file_path, api_version='v2'):
     """ Connect to the google play interface
     """
 
@@ -194,6 +194,6 @@ def _connect(service_account, credentials_file_path):
     http = httplib2.Http()
     http = credentials.authorize(http)
 
-    service = build('androidpublisher', 'v2', http=http, cache_discovery=False)
+    service = build('androidpublisher', api_version, http=http, cache_discovery=False)
 
     return service

--- a/mozapkpublisher/test/common/test_googleplay.py
+++ b/mozapkpublisher/test/common/test_googleplay.py
@@ -37,7 +37,7 @@ def set_up_edit_service_mock(_monkeypatch):
     edit_service_mock.insert = lambda body, packageName: new_transaction_mock
     general_service_mock.edits = lambda: edit_service_mock
 
-    _monkeypatch.setattr('mozapkpublisher.common.googleplay._connect', lambda _, __: general_service_mock)
+    _monkeypatch.setattr('mozapkpublisher.common.googleplay.connect', lambda _, __: general_service_mock)
     return edit_service_mock
 
 

--- a/mozapkpublisher/test/test_check_rollout.py
+++ b/mozapkpublisher/test/test_check_rollout.py
@@ -1,0 +1,106 @@
+# coding: utf-8
+
+import email.utils as eu
+import random
+import time
+from unittest.mock import MagicMock
+
+import pytest
+
+from mozapkpublisher import check_rollout
+
+
+def set_up_mocks(_requests_mock, tracks):
+    now = time.time()
+    yesterday = now - check_rollout.DAY
+    a_long_time_ago = now - 10 * check_rollout.DAY
+    _requests_mock.head('https://archive.mozilla.org/pub/mobile/releases/{}/SHA512SUMS'.format('61.0'),
+                        status_code=200, headers={'Last-Modified': eu.formatdate(yesterday, usegmt=True)})
+    _requests_mock.head('https://archive.mozilla.org/pub/mobile/releases/{}/SHA512SUMS'.format('60.0.2'),
+                        status_code=200, headers={'Last-Modified': eu.formatdate(a_long_time_ago, usegmt=True)})
+    _requests_mock.head('https://archive.mozilla.org/pub/mobile/releases/{}/SHA512SUMS'.format('62.0'),
+                        status_code=404)
+
+    edit_service_mock = MagicMock()
+    new_transaction_mock = MagicMock()
+    tracks_mock = MagicMock()
+    tracks_get_mock = MagicMock()
+
+    edit_service_mock.insert = lambda body, packageName: new_transaction_mock
+    edit_service_mock.tracks = lambda: tracks_mock
+    new_transaction_mock.execute = lambda: {'id': random.randint(0, 1000)}
+    tracks_mock.get = lambda editId=None, track=None, packageName=None: tracks_get_mock
+    tracks_get_mock.execute = tracks
+
+    return edit_service_mock
+
+
+def test_new_rollout(requests_mock):
+    """61.0 is in partial rollout since yesterday, 60.0.1 is at full rollout"""
+    def tracks():
+        return {'releases': [
+                {'name': '61.0',
+                 'versionCodes': ['2015506297', '2015506300', '2015565729', '2015565732'],
+                 'releaseNotes': [
+                    {'language': 'sk', 'text': '* Vylepšenia v rámci Quantum CSS, ktoré urýchľujú načítanie stránok\n* Rýchlejšie posúvanie sa na stránkach'}
+                 ],
+                 'status': 'inProgress',
+                 'userFraction': .1,
+                 },
+                {'name': '60.0.1',
+                 'versionCodes': ['2015558697', '2015558700'],
+                 'status': 'completed',
+                 }]}
+    edit_service_mock = set_up_mocks(requests_mock, tracks)
+
+    with pytest.raises(StopIteration):
+        next(check_rollout.check_rollout(edit_service_mock, 'org.mozilla.firefox', 7))
+
+    gen = check_rollout.check_rollout(edit_service_mock, 'org.mozilla.firefox', .5)
+    release, age = next(gen)
+    assert release['name'] == '61.0'
+    assert age >= check_rollout.DAY
+    with pytest.raises(StopIteration):
+        next(gen)
+
+
+def test_old_rollout(requests_mock):
+    """60.0.2 is in partial rollout for a long time; 60.0.1 is at full rollout"""
+    def tracks():
+        return {'releases': [
+                {'name': '60.0.2',
+                 'versionCodes': ['2015562697', '2015562700'],
+                 'status': 'inProgress',
+                 'userFraction': .99,
+                 },
+                {'name': '60.0.1',
+                 'versionCodes': ['2015558697', '2015558700'],
+                 'status': 'completed',
+                 }]}
+    edit_service_mock = set_up_mocks(requests_mock, tracks)
+
+    gen = check_rollout.check_rollout(edit_service_mock, 'org.mozilla.firefox', 7)
+    release, age = next(gen)
+    assert release['name'] == '60.0.2'
+    assert age >= 10 * check_rollout.DAY
+    with pytest.raises(StopIteration):
+        next(gen)
+
+
+def test_rc_rollout(requests_mock):
+    """62.0 is not released yet but RC is being rolled out; 61.0 is at full rollout"""
+    def tracks():
+        return {'releases': [
+                {'name': '62.0',
+                 'versionCodes': ['2015558697', '2015558700'],
+                 'status': 'inProgress',
+                 'userFraction': .05,
+                 },
+                {'name': '61.0',
+                 'versionCodes': ['2015506297', '2015506300', '2015565729', '2015565732'],
+                 'status': 'completed',
+                 }]}
+    edit_service_mock = set_up_mocks(requests_mock, tracks)
+
+    with pytest.raises(StopIteration):
+        next(check_rollout.check_rollout(edit_service_mock, 'org.mozilla.firefox', 7))


### PR DESCRIPTION
…oo long

We've had a few cases of a release being staged at 99% and forgetting to
finish the rollout by bumping it to 100%, then having that release
overwritten by the next one at 5 or 10%.  Let's try to avoid that by
checking for a 7-day-old release on staged rollout and nagging.

Ideally this would use mozapkpublisher.common.googleplay but that would require use of v3 API (#67) so this is standalone for now.