### PR TITLE
Remove regex to infer the type of a Firefox version

### DIFF
--- a/mozapkpublisher/common/apk/checker.py
+++ b/mozapkpublisher/common/apk/checker.py
@@ -1,7 +1,8 @@
 import logging
-import re
 
 from functools import partial
+
+from mozilla_version.firefox import FirefoxVersion
 
 from mozapkpublisher.common.apk.history import get_expected_api_levels_for_version, get_expected_architectures_for_version
 from mozapkpublisher.common.exceptions import BadApk, BadSetOfApks, NotMultiLocaleApk
@@ -9,18 +10,6 @@ from mozapkpublisher.common.utils import filter_out_identical_values, PRODUCT
 
 logger = logging.getLogger(__name__)
 
-
-_MATCHING_VERSION_NUMBER_PER_PACKAGE_NAME = {
-    # Due to project Dawn, Nightly is now using the Aurora package name. See bug 1357351.
-    'org.mozilla.fennec_aurora': re.compile(r'^\d+\.0a1$'),
-    # XXX Betas aren't following the regular XX.0bY format. Instead they follow XX.0.
-    'org.mozilla.firefox_beta': re.compile(r'^\d+\.0$'),
-    # Simplified regex. We don't need something as complex as
-    # https://github.com/mozilla-releng/ship-it/blob/890929b0c3e6df1b72489d2f3cf60450b91114f2/kickoff/static/model/release.js#L4
-    # because we just want to check that 56.0b1 is not shipped with
-    # the package name org.mozilla.firefox, for instance
-    'org.mozilla.firefox': re.compile(r'^\d+\.\d+(\.\d+)?$'),
-}
 
 # x86 must have the highest version code. See bug 1338477 for more context.
 # TODO: Support ARM64, once bug 1368484 is ready
@@ -95,11 +84,27 @@ _check_all_apks_have_the_same_locales = partial(_check_piece_of_metadata_is_uniq
 
 
 def _check_version_matches_package_name(version, package_name):
-    regex = _MATCHING_VERSION_NUMBER_PER_PACKAGE_NAME[package_name]
-    if regex.match(version) is None:
-        raise BadApk('Wrong version number "{}" for package name "{}"'.format(version, package_name))
+    sanitized_version = FirefoxVersion(version)
 
-    logger.info('Firefox version "{}" matches package name "{}"'.format(version, package_name))
+    if (
+        (package_name == 'org.mozilla.firefox' and sanitized_version.is_release) or
+        # Due to project Dawn, Nightly is now using the Aurora package name. See bug 1357351.
+        (package_name == 'org.mozilla.fennec_aurora' and sanitized_version.is_nightly) or
+        (
+            # XXX Betas aren't following the regular XX.0bY format. Instead they follow XX.0
+            # (which looks like release). Therefore, we can't use sanitized_version.is_beta
+            package_name == 'org.mozilla.firefox_beta'
+            and sanitized_version.is_release
+            and sanitized_version.minor_number == 0
+            # We ensure the patch_number is undefined. Calling sanitized_version.patch_number
+            # directly raises an (expected) AttributeError
+            and getattr(sanitized_version, 'patch_number', None) is None
+        )
+    ):
+        logger.info('Firefox version "{}" matches package name "{}"'.format(version, package_name))
+
+    else:
+        raise BadApk('Wrong version number "{}" for package name "{}"'.format(version, package_name))
 
 
 def _check_apks_version_codes_are_correctly_ordered(apks_metadata_per_paths):

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,6 @@
 google-api-python-client
 oauth2client
+mozilla-version
 pyOpenSSL
 requests
 voluptuous


### PR DESCRIPTION
While working on Fennec related work, I remembered push_apk used regexes too. Beta is little bit weird in this example, this is why the condition looks awkward and less straightforward than the example.

As you may use the `mozilla-version` library, would you like to take a look at its usage, @Callek ? r? 