### PR TITLE
Bug 1496090 - get_l10n_strings: Do not call version specific URLs anymore

### DIFF
--- a/mozapkpublisher/get_l10n_strings.py
+++ b/mozapkpublisher/get_l10n_strings.py
@@ -19,15 +19,11 @@ class GetL10nStrings(Base):
 
         cls.parser.add_argument('--package-name', choices=store_l10n.STORE_PRODUCT_DETAILS_PER_PACKAGE_NAME.keys(),
                                 help='The APK package name', required=True)
-        cls.parser.add_argument('--major-version-number',
-                                help='The APK major version (e.g.: 60 for Firefox 60.0.1)', default=None)
-        cls.parser.add_argument('--output-file', type=argparse.FileType('w'),
-                                help='The file where strings will be saved to', default='l10n_strings.json')
+        cls.parser.add_argument('--output-file', type=argparse.FileType('w'), help='The file where strings will be saved to',
+                                default='l10n_strings.json')
 
     def run(self):
-        l10n_strings = store_l10n.get_translations_per_google_play_locale_code(
-            self.config.package_name, self.config.major_version_number
-        )
+        l10n_strings = store_l10n.get_translations_per_google_play_locale_code(self.config.package_name)
         json.dump(l10n_strings, self.config.output_file)
 
 

--- a/mozapkpublisher/test/common/test_store_l10n.py
+++ b/mozapkpublisher/test/common/test_store_l10n.py
@@ -101,33 +101,20 @@ def test_get_list_of_completed_locales(monkeypatch):
 
 
 def test_get_translation(monkeypatch):
-    def fake_load_json_url(url):
-        if url == 'https://l10n.mozilla-community.org/stores_l10n/api/v1/fx_android/translation/beta/en-GB/':
-            return {
-                'title': 'Firefox for Android Beta',
-                'long_desc': 'Long description',
-                'short_desc': 'Short',
-                'whatsnew': 'Whatsnew tied to beta channel',
-            }
-        elif url == 'https://l10n.mozilla-community.org/stores_l10n/api/v1/fx_android/translation/60/en-GB/':
-            return {
-                'whatsnew': 'Whatsnew tied to version 60',
-            }
-
-    monkeypatch.setattr(utils, 'load_json_url', fake_load_json_url)
-
+    monkeypatch.setattr(
+        utils, 'load_json_url',
+        lambda url: {
+            'title': 'Firefox for Android Beta',
+            'long_desc': 'Long description',
+            'short_desc': 'Short',
+            'whatsnew': 'Check out this cool feature!'
+        } if url == 'https://l10n.mozilla-community.org/stores_l10n/api/v1/fx_android/translation/beta/en-GB/' else None
+    )
     assert _get_translation('fx_android', 'beta', 'en-GB') == {
         'title': 'Firefox for Android Beta',
         'long_desc': 'Long description',
         'short_desc': 'Short',
-        'whatsnew': 'Whatsnew tied to beta channel',
-    }
-
-    assert _get_translation('fx_android', 'beta', 'en-GB', '60') == {
-        'title': 'Firefox for Android Beta',
-        'long_desc': 'Long description',
-        'short_desc': 'Short',
-        'whatsnew': 'Whatsnew tied to version 60',
+        'whatsnew': 'Check out this cool feature!',
     }
 
 


### PR DESCRIPTION
stores_l10n used to expose https://l10n.mozilla-community.org/stores_l10n/api/v1/fx_android/translation/61/fr/
for instance, but now reports errors. Therefore, there is no need to
deprecate the command line argument. Let's just get rid of it.

Revert "Bug 1459181 - get_l10n_strings: fetch version-specific "whatsnew" section if provided"

This reverts commit d34a49ac9e8069ce9a176da54c390b3e5ccf0f40.