### PR TITLE
Runs file-creating test in temporary directory

### DIFF
--- a/mozapkpublisher/test/test_get_l10n_strings.py
+++ b/mozapkpublisher/test/test_get_l10n_strings.py
@@ -1,16 +1,30 @@
+import os
 import pytest
 import sys
 
+from contextlib import contextmanager
 from mozapkpublisher.common.exceptions import WrongArgumentGiven
 from mozapkpublisher.get_l10n_strings import main
 
 
-def test_main(monkeypatch):
-    incomplete_args = [
-        '--output-file', 'some_file',
-    ]
+@contextmanager
+def working_directory(path):
+    original_cwd = os.getcwd()
+    os.chdir(str(path))
+    yield
+    os.chdir(original_cwd)
 
-    monkeypatch.setattr(sys, 'argv', incomplete_args)
 
-    with pytest.raises(WrongArgumentGiven):
-        main()
+def test_main(tmp_path, monkeypatch):
+    # get_l10n_strings produces a file in the working directory
+    with working_directory(tmp_path):
+        print('cwd is {}', os.getcwd())
+
+        incomplete_args = [
+            '--output-file', 'some_file',
+        ]
+
+        monkeypatch.setattr(sys, 'argv', incomplete_args)
+
+        with pytest.raises(WrongArgumentGiven):
+            main()


### PR DESCRIPTION
Whenever we run our `get_l10n_strings` test, it creates a file in our `mozapkpublisher/test` directory that isn't `gitignore`'d.
I think that if our tests create temporary files, we should use a temporary directory (e.g.: what if we assert on such files in the future? The state should be clean).

This PR ensures that a temp directory is used for the environment-mutating test