### PR TITLE
Remove Python 3.5 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,6 @@ language: python
 
 matrix:
   include:
-    - python: 3.5
-      env:
-        - TOXENV=py35
-        - SKIP_NETWORK_TESTS=0
     - python: 3.6
       env:
         - TOXENV=py36

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Scripts to publish Firefox for Android on Google Play Store.
 
 ## Setup and run
 
-1. :warning: You need Python >= 3.5 to run this set of scripts. Python 2 isn't supported starting version 0.5.0
+1. :warning: You need Python >= 3.6 to run this set of scripts. Python 2 isn't supported starting version 0.5.0. Python 3.5 was removed in version 3.0.0.
 1. Create a virtualenv and source it
 ```sh
 virtualenv -p python3 venv

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
     license='MPL2',
     install_requires=requirements,
     classifiers=(
-        'Development Status :: 3 - Alpha',
-        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
     ),
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py35, py36, py37
+envlist = py36, py37
 
 [testenv]
 setenv =


### PR DESCRIPTION
In #196, a python3.5-specific error broke these tests: https://travis-ci.org/mozilla-releng/mozapkpublisher/jobs/537876097#L849.

We don't use python 3.5 anymore in production. Scriptworker itself doesn't support this version anymore https://github.com/mozilla-releng/scriptworker/blob/c3953fccc8860073b1f87cf7cc50c89cdedba92d/setup.py#L93. 

On the other side, mozapkpublisher can be run on a local machine and Python 3.5 is supported for another year and a half. I think it's fine to remove this support, based on the usage of this package. What do you think @mitchhentges ? 