### PR TITLE
Fix focus/klar pushes which were sent in the same request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [6.0.0] - TBD
 
+### Fixed
+* Focus and Klar were sent in the same transaction, which cannot happen.
+
 ### Removed
 * `update_apk_description.py`: https://l10n.mozilla-community.org/stores_l10n/ is now retired making the script useless.
 * `get_l10n_strings.py`: Automation hasn't used this script since [Bug 1560876](https://bugzilla.mozilla.org/show_bug.cgi?id=1560876). Moreover, like `update_apk_description.py`, this script doesn't work anymore.

--- a/mozapkpublisher/push_apk.py
+++ b/mozapkpublisher/push_apk.py
@@ -71,7 +71,7 @@ def push_apk(
     for (package_name, apks_metadata) in split_apk_metadata.items():
         with googleplay.edit(service_account, google_play_credentials_file.name, package_name,
                              contact_google_play=contact_google_play, commit=commit) as edit:
-            for path, metadata in apks_metadata_per_paths.items():
+            for path in apks_metadata.keys():
                 edit.upload_apk(path)
 
             all_version_codes = _get_ordered_version_codes(apks_metadata_per_paths)


### PR DESCRIPTION
Fixes https://tools.taskcluster.net/groups/FEM11DlNQ3m9RIk-03C5ZA/tasks/XRz-C2iITNWMFmFEBN5zJA/runs/0/logs/public%2Flogs%2Flive_backing.log which was reported by @ColinTheShots 

I tried to make a test out for this fix, but I didn't manage to get something simple enough. I think it's a good case for an integration test which would easier to do with bug 1575691. What do you think @mitchhentges 