### PR TITLE
Remove unused code and dependency

### DIFF
--- a/mozapkpublisher/common/utils.py
+++ b/mozapkpublisher/common/utils.py
@@ -2,8 +2,6 @@ import hashlib
 import logging
 import requests
 
-from mozilla_version.gecko import FennecVersion
-
 logger = logging.getLogger(__name__)
 
 
@@ -24,14 +22,6 @@ def file_sha512sum(file_path):
 
 def filter_out_identical_values(list_):
     return list(set(list_))
-
-
-def is_firefox_version_nightly(firefox_version):
-    version = FennecVersion.parse(firefox_version)
-    if not (version.is_nightly or version.is_beta or version.is_release):
-        raise ValueError('Unsupported version: {}'.format(firefox_version))
-
-    return version.is_nightly
 
 
 def add_push_arguments(parser):

--- a/mozapkpublisher/test/common/test_utils.py
+++ b/mozapkpublisher/test/common/test_utils.py
@@ -1,11 +1,10 @@
-import pytest
 import requests
 import tempfile
 
 from tempfile import NamedTemporaryFile
 from unittest.mock import MagicMock
 
-from mozapkpublisher.common.utils import load_json_url, file_sha512sum, is_firefox_version_nightly, metadata_by_package_name
+from mozapkpublisher.common.utils import load_json_url, file_sha512sum, metadata_by_package_name
 
 apk_x86 = NamedTemporaryFile()
 apk_arm = NamedTemporaryFile()
@@ -26,20 +25,6 @@ def test_file_sha512sum():
 
         assert file_sha512sum(temp_file.name) == '0b1622c08ae1fcffe9f0d1dd17fe273d7e8c96668981c8a38f6bbfa4f757b30af0\
 ed2aabf90f1f8a5983082a0b88194fe81bc850d3019fd9eca9328584227c84'
-
-
-@pytest.mark.parametrize('version, expected', (
-    ('66.0a1', True),
-    ('66.0b2', False),
-    ('66.0', False),
-))
-def test_is_firefox_version_nightly(version, expected):
-    assert is_firefox_version_nightly(version) == expected
-
-
-def test_bad_is_firefox_version_nightly():
-    with pytest.raises(ValueError):
-        is_firefox_version_nightly('66.0esr')
 
 
 def test_metadata_by_package_name():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,6 @@ dependencies = [
     "mozilla-version",
     "pyaxmlparser",
     "requests",
-    "voluptuous",
     "pyjwt",
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -629,7 +629,6 @@ dependencies = [
     { name = "pyaxmlparser" },
     { name = "pyjwt" },
     { name = "requests" },
-    { name = "voluptuous" },
 ]
 
 [package.dev-dependencies]
@@ -657,7 +656,6 @@ requires-dist = [
     { name = "pyaxmlparser" },
     { name = "pyjwt" },
     { name = "requests" },
-    { name = "voluptuous" },
 ]
 
 [package.metadata.requires-dev]
@@ -1094,15 +1092,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/aa/63/e53da845320b757bf29ef6a9062f5c669fe997973f966045cb019c3f4b66/urllib3-2.3.0.tar.gz", hash = "sha256:f8c5449b3cf0861679ce7e0503c7b44b5ec981bec0d1d3795a07f1ba96f0204d", size = 307268, upload-time = "2024-12-22T07:47:30.032Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c8/19/4ec628951a74043532ca2cf5d97b7b14863931476d117c471e8e2b1eb39f/urllib3-2.3.0-py3-none-any.whl", hash = "sha256:1cee9ad369867bfdbbb48b7dd50374c0967a0bb7710050facf0dd6911440e3df", size = 128369, upload-time = "2024-12-22T07:47:28.074Z" },
-]
-
-[[package]]
-name = "voluptuous"
-version = "0.15.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/91/af/a54ce0fb6f1d867e0b9f0efe5f082a691f51ccf705188fca67a3ecefd7f4/voluptuous-0.15.2.tar.gz", hash = "sha256:6ffcab32c4d3230b4d2af3a577c87e1908a714a11f6f95570456b1849b0279aa", size = 51651, upload-time = "2024-07-02T19:10:00.528Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/db/a8/8f9cc6749331186e6a513bfe3745454f81d25f6e34c6024f88f80c71ed28/voluptuous-0.15.2-py3-none-any.whl", hash = "sha256:016348bc7788a9af9520b1764ebd4de0df41fe2138ebe9e06fa036bf86a65566", size = 31349, upload-time = "2024-07-02T19:09:58.125Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
`is_firefox_version_nightly` is unused since 1e7d15de534ddd5bd5be09435523dc9c2008ebcc
`voluptuous` is unused since 5421be196182f94a8372ab95d630d553690f73bd

Fixes #270 