### PR TITLE
Bug 1972858 - Add a config option to disable submitting SGS updates

### DIFF
--- a/mozapkpublisher/common/utils.py
+++ b/mozapkpublisher/common/utils.py
@@ -29,6 +29,7 @@ def add_push_arguments(parser):
     parser.add_argument('--secret', help='File that contains google credentials (json). This is only required if the store is google.')
     parser.add_argument('--sgs-service-account-id', help='The service account ID for the samsung galaxy store. This is only required if the store is samsung')
     parser.add_argument('--sgs-access-token', help='The access token for the samsung galaxy store. This is only required if the store is samsung')
+    parser.add_argument('--submit', help='Submit the submission for review. This doesn\'t change anything unless the store is samsung', action='store_true')
     parser.add_argument('--do-not-contact-server', action='store_false', dest='contact_server',
                         help='''Prevent any request to reach the APK server. Use this option if
 you want to run the script without any valid credentials nor valid APKs. --credentials must

--- a/mozapkpublisher/push_apk.py
+++ b/mozapkpublisher/push_apk.py
@@ -28,6 +28,7 @@ async def push_apk(
     skip_check_same_locales=False,
     skip_checks_fennec=False,
     *,
+    submit=False,
     sgs_service_account_id=None,
     sgs_access_token=None,
 ):
@@ -85,7 +86,7 @@ async def push_apk(
 
         async with SamsungGalaxyStore(sgs_service_account_id, sgs_access_token, dry_run=dry_run) as sgs:
             for package_name, apks in apks_by_package_name.items():
-                await sgs.upload_apks(package_name, apks, rollout_percentage)
+                await sgs.upload_apks(package_name, apks, rollout_percentage, submit=submit)
     else:
         raise WrongArgumentGiven("Unkown target store: {}".format(store))
 
@@ -110,6 +111,7 @@ def main():
         config.skip_check_multiple_locales,
         config.skip_check_same_locales,
         config.skip_checks_fennec,
+        submit=config.submit,
         sgs_service_account_id=config.sgs_service_account_id,
         sgs_access_token=config.sgs_access_token,
     ))

--- a/mozapkpublisher/sgs_api/__init__.py
+++ b/mozapkpublisher/sgs_api/__init__.py
@@ -29,7 +29,7 @@ class SamsungGalaxyStore:
     async def __aexit__(self, *args: Any) -> None:
         await self.api.__aexit__(*args)
 
-    async def upload_apks(self, package_name, apks, rollout_rate):
+    async def upload_apks(self, package_name, apks, rollout_rate, submit=False):
         """
         Upload the APKs passed as arguments. The app to be updated will be infered from the package name.
         If the rollout_rate is not None, all new apks will be added to a staged rollout with that rate.
@@ -94,7 +94,8 @@ class SamsungGalaxyStore:
 
             await self.api.enable_staged_rollout(content_id, rollout_rate)
 
-        await self.api.submit_app(content_id)
+        if submit:
+            await self.api.submit_app(content_id)
 
     async def upload_file(self, file):
         """

--- a/mozapkpublisher/test/test_push_apk.py
+++ b/mozapkpublisher/test/test_push_apk.py
@@ -141,6 +141,7 @@ def test_main_google(monkeypatch):
             False,
             False,
             False,
+            submit=False,
             sgs_service_account_id=None,
             sgs_access_token=None
         )
@@ -153,6 +154,7 @@ def test_main_samsung(monkeypatch):
         '--store', 'samsung',
         '--sgs-service-account-id', '123',
         '--sgs-access-token', '456',
+        '--submit',
         'alpha',
         file,
         '--expected-package-name=org.mozilla.fennec_aurora',
@@ -175,6 +177,7 @@ def test_main_samsung(monkeypatch):
             False,
             False,
             False,
+            submit=True,
             sgs_service_account_id='123',
             sgs_access_token='456'
         )


### PR DESCRIPTION
After discussing with relman, they'd rather be able to edit the submission before it gets sent for testing as it becomes immutable at that point until it is validated (including description, rollouts, ...)