### PR TITLE
Bug 1974870 - Upload APKs to SGS with a unique name

### DIFF
--- a/mozapkpublisher/common/apk/extractor.py
+++ b/mozapkpublisher/common/apk/extractor.py
@@ -41,6 +41,7 @@ def extract_metadata(original_apk_path, extract_architecture_metadata, extract_l
         metadata['package_name'] = package_name
         metadata['api_level'] = int(parsed_apk.get_min_sdk_version())
         metadata['version_code'] = parsed_apk.get_androidversion_code()
+        metadata['version_name'] = parsed_apk.get_androidversion_name()
 
         with ZipFile(apk_copy.name) as apk_zip:
             if extract_architecture_metadata:

--- a/mozapkpublisher/test/common/apk/test_extractor.py
+++ b/mozapkpublisher/test/common/apk/test_extractor.py
@@ -89,6 +89,7 @@ def test_extract_metadata(monkeypatch):
     pyaxmlparser_mock.get_package = lambda: 'org.mozilla.firefox'
     pyaxmlparser_mock.get_min_sdk_version = lambda: 16
     pyaxmlparser_mock.get_androidversion_code = lambda: '2015523300'
+    pyaxmlparser_mock.get_androidversion_name = lambda: '129.0'
     monkeypatch.setattr(pyaxmlparser, 'APK', lambda _: pyaxmlparser_mock)
 
     with TemporaryDirectory() as temp_dir:
@@ -101,6 +102,7 @@ def test_extract_metadata(monkeypatch):
             'locales': ('an', 'as', 'bn-IN', 'en-GB', 'en-US'),
             'package_name': 'org.mozilla.firefox',
             'version_code': '2015523300',
+            'version_name': '129.0',
         }
 
 

--- a/mozapkpublisher/test/integration/test_upload_sgs.py
+++ b/mozapkpublisher/test/integration/test_upload_sgs.py
@@ -261,6 +261,7 @@ def fake_apk_metadata(files, *args, **kwargs):
             "package_name": "org.mozilla.focus",
             "api_level": 21,
             "version_code": "390842050",
+            "version_name": "137.1",
             "architecture": "armeabi-v7a",
             "locales": ("fr", "en"),
         }
@@ -285,6 +286,9 @@ class ExpectedFormData:
             assert (
                 expected_filename is None or "filename" in ty_options
             ), f"Was expecting filename for field {name} but it's missing"
+
+            if "filename" in ty_options and expected_filename is not None:
+                assert ty_options["filename"] == expected_filename
 
         return True
 
@@ -327,7 +331,7 @@ async def test_update_ok(responses, monkeypatch, rollout_rate, submit):
 
     expected_file_upload = (
         ExpectedFormData()
-        .add_field("file", b"laksdjflsakjdf\n", filename="blob")
+        .add_field("file", b"laksdjflsakjdf\n", filename="org.mozilla.focus-armeabi-v7a-137.1.apk")
         .add_field("sessionId", "789")
     )
 

--- a/mozapkpublisher/test/sgs/test_submit.py
+++ b/mozapkpublisher/test/sgs/test_submit.py
@@ -146,7 +146,7 @@ async def test_upload_apk(sgs, responses_mock, status, response, expectation):
     with tempfile.NamedTemporaryFile("w") as tmp, expectation as exc:
         tmp.write("1" * 10)
         tmp.flush()
-        res = await sgs.upload_file(str(session_id), tmp.name)
+        res = await sgs.upload_file(str(session_id), tmp.name, "foobar")
 
     responses_mock.assert_called_with(
         url="https://seller.samsungapps.com/galaxyapi/fileUpload",


### PR DESCRIPTION
Turns out the API asks for a binarySeq for absolutely **no reason whatsoever** since they also expect every file name to be unique. I can't wait to discover that the filename cannot contain any `.` except for the extension or that there's a max size at 20 characters for no good reason. Given the rest of the API that would not even surprise me...

This is untested because we have to test in prod, they don't offer any way of having a test app; but that's how forms work, so hopefully they don't do anything stupid on their side...