### PR TITLE
Always extract architecture metadata from APKs

### DIFF
--- a/mozapkpublisher/common/apk/__init__.py
+++ b/mozapkpublisher/common/apk/__init__.py
@@ -35,8 +35,7 @@ def extract_and_check_apks_metadata(
     skip_check_ordered_version_codes,
 ):
     apks_metadata = {
-        apk: extract_metadata(apk.name, not skip_check_ordered_version_codes,
-                              not skip_check_same_locales and not skip_check_multiple_locales,
+        apk: extract_metadata(apk.name, not skip_check_same_locales and not skip_check_multiple_locales,
                               not skip_checks_fennec)
         for apk in apks
     }

--- a/mozapkpublisher/common/apk/extractor.py
+++ b/mozapkpublisher/common/apk/extractor.py
@@ -26,8 +26,7 @@ _OMNI_JA_LOCATION = 'assets/omni.ja'
 _CHROME_MANIFEST_LOCATION = 'chrome/chrome.manifest'
 
 
-def extract_metadata(original_apk_path, extract_architecture_metadata, extract_locale_metadata,
-                     extract_firefox_metadata):
+def extract_metadata(original_apk_path, extract_locale_metadata, extract_firefox_metadata):
     logger.info('Extracting metadata from a copy of "{}"...'.format(original_apk_path))
     metadata = {}
 
@@ -44,8 +43,7 @@ def extract_metadata(original_apk_path, extract_architecture_metadata, extract_l
         metadata['version_name'] = parsed_apk.get_androidversion_name()
 
         with ZipFile(apk_copy.name) as apk_zip:
-            if extract_architecture_metadata:
-                metadata['architecture'] = _extract_architecture(apk_zip, original_apk_path)
+            metadata['architecture'] = _extract_architecture(apk_zip, original_apk_path)
 
             if extract_locale_metadata:
                 metadata['locales'] = _extract_locales(apk_zip)

--- a/mozapkpublisher/test/common/apk/test_extractor.py
+++ b/mozapkpublisher/test/common/apk/test_extractor.py
@@ -105,6 +105,33 @@ def test_extract_metadata(monkeypatch):
             'version_name': '129.0',
         }
 
+        assert extract_metadata(apk_file, True, False) == {
+            'api_level': 16,
+            'architecture': 'x86',
+            'locales': ('an', 'as', 'bn-IN', 'en-GB', 'en-US'),
+            'package_name': 'org.mozilla.firefox',
+            'version_code': '2015523300',
+            'version_name': '129.0',
+        }
+
+        assert extract_metadata(apk_file, False, True) == {
+            'api_level': 16,
+            'architecture': 'x86',
+            'firefox_build_id': '20171112125738',
+            'firefox_version': '57.0',
+            'package_name': 'org.mozilla.firefox',
+            'version_code': '2015523300',
+            'version_name': '129.0',
+        }
+
+        assert extract_metadata(apk_file, False, False) == {
+            'api_level': 16,
+            'architecture': 'x86',
+            'package_name': 'org.mozilla.firefox',
+            'version_code': '2015523300',
+            'version_name': '129.0',
+        }
+
 
 @pytest.mark.parametrize('architecture', (('x86', 'armeabi-v7a')))
 def test_get_apk_architecture(architecture):

--- a/mozapkpublisher/test/common/apk/test_extractor.py
+++ b/mozapkpublisher/test/common/apk/test_extractor.py
@@ -94,7 +94,7 @@ def test_extract_metadata(monkeypatch):
 
     with TemporaryDirectory() as temp_dir:
         apk_file = _create_apk_with_all_metadata(temp_dir)
-        assert extract_metadata(apk_file, True, True, True) == {
+        assert extract_metadata(apk_file, True, True) == {
             'api_level': 16,
             'architecture': 'x86',
             'firefox_build_id': '20171112125738',


### PR DESCRIPTION
We depend on the architecture being present in the metadata when uploading binaries to the samsung galaxy store. This isn't the case for focus because we pass `skip_check_ordered_version_codes` which in turn leads to the architecture metadata not being extracted.

Unlike the other flagged metadata extraction, this one doesn't seem to be able to fail nor does it make this function slower (there's less than a 1% perf difference) so let's just unconditionally extract it and remove part of a footgun in the API.

Fixes #282