### PR TITLE
Bug 2052916 - Use the dedicated APIs to add/delete files to content IDs

### DIFF
--- a/mozapkpublisher/sgs_api/__init__.py
+++ b/mozapkpublisher/sgs_api/__init__.py
@@ -51,46 +51,33 @@ class SamsungGalaxyStore:
         current_info = content_info[0]
 
         # Because infer_content_id_from_package_name relies on a binary with the package name existing, we know that binary_list here is not empty
-        last_binary = max((binary for binary in current_info.binary_list), key=lambda binary: int(binary["binarySeq"]))
-        last_binary_id = int(last_binary["binarySeq"])
+        existing_binaries = current_info.binary_list
+        last_binary = max(existing_binaries, key=lambda binary: int(binary["binarySeq"]))
 
+        gms = last_binary["gms"]
+
+        # Transition the app to `REGISTERING`
+        await self.api.update_content_info(current_info)
+
+        binaries_oldest_first = sorted(existing_binaries, key=lambda binary: int(binary["binarySeq"]))
+
+        binaries_to_delete = max(0, len(existing_binaries) + len(apks) - 20)
+        for binary in binaries_oldest_first[:binaries_to_delete]:
+            await self.api.delete_binary(content_id, binary["binarySeq"])
+
+        new_binary_seqs = []
         for apk in apks:
             fd, metadata = apk
 
             file_name = "{}-{}-{}.apk".format(metadata["package_name"], metadata["architecture"], metadata["version_name"])
             file_key = await self.upload_file(fd.name, file_name)
-            new_binary = {
-                "fileName": os.path.basename(fd.name),
-                "versionCode": metadata["version_code"],
-                "binarySeq": last_binary_id + 1,
-                "packageName": metadata["package_name"],
-                "apiminSdkVersion": metadata["api_level"],
-                "apimaxSdkversion": None,
-                "iapSdk": last_binary["iapSdk"],
-                "gms": last_binary["gms"],
-                "filekey": file_key,
-            }
-
-            current_info.add_binary(new_binary)
-            last_binary_id += 1
-
-        await self.api.update_content_info(current_info)
+            result = await self.api.add_binary(
+                content_id, file_key, gms
+            )
+            new_binary_seqs.append(result["data"]["binarySeq"])
 
         if rollout_rate is not None:
-            # Grab the actual content as samsung requires us to
-            try:
-                new_content_info = next(ci for ci in await self.api.get_content_info(content_id) if ci.status == "UPDATING")
-            except StopIteration:
-                raise SgsUpdateException(
-                    "The API didn't return a content info with the UPDATING status. Unable to create a rollout"
-                )
-
-            new_binaries = [
-                binary["binarySeq"]
-                for binary in new_content_info.binary_list
-                if binary["versionCode"] in (apk["version_code"] for (_, apk) in apks)
-            ]
-            for new_bin in new_binaries:
+            for new_bin in new_binary_seqs:
                 await self.api.add_binary_to_staged_rollout(content_id, new_bin)
 
             await self.api.enable_staged_rollout(content_id, rollout_rate)
@@ -272,7 +259,6 @@ class SamsungGalaxyApi:
         content_id: str,
         file_key: str,
         gms: str,
-        binary_seq_for_device_info: str = None,
     ) -> Dict[str, Any]:
         """
         Register an uploaded file as a new binary for the given content. The app must
@@ -287,9 +273,6 @@ class SamsungGalaxyApi:
             "filekey": file_key,
             "gms": gms,
         }
-
-        if binary_seq_for_device_info is not None:
-            data["binarySeqForDeviceInfo"] = binary_seq_for_device_info
 
         return await self._request("POST", "/seller/v2/content/binary", json=data)
 

--- a/mozapkpublisher/sgs_api/__init__.py
+++ b/mozapkpublisher/sgs_api/__init__.py
@@ -267,6 +267,48 @@ class SamsungGalaxyApi:
             "POST", "/seller/contentUpdate", json=new_content_info.as_new_data()
         )
 
+    async def add_binary(
+        self,
+        content_id: str,
+        file_key: str,
+        gms: str,
+        binary_seq_for_device_info: str = None,
+    ) -> Dict[str, Any]:
+        """
+        Register an uploaded file as a new binary for the given content. The app must
+        already be in the `REGISTERING`/`UPDATING` state.
+
+        The returned payload contains the new binary sequence at `data.binarySeq`.
+
+        https://developer.samsung.com/galaxy-store/galaxy-store-developer-api/content-publish-api/add-new-binary.html
+        """
+        data = {
+            "contentId": content_id,
+            "filekey": file_key,
+            "gms": gms,
+        }
+
+        if binary_seq_for_device_info is not None:
+            data["binarySeqForDeviceInfo"] = binary_seq_for_device_info
+
+        return await self._request("POST", "/seller/v2/content/binary", json=data)
+
+    async def delete_binary(
+        self, content_id: str, binary_seq: str
+    ) -> Dict[str, Any]:
+        """
+        Delete an existing binary from the given content. The app must already be in
+        the `REGISTERING`/`UPDATING` state.
+
+        https://developer.samsung.com/galaxy-store/galaxy-store-developer-api/content-publish-api/delete-binary.html
+        """
+        params = {
+            "contentId": content_id,
+            "binarySeq": binary_seq,
+        }
+
+        return await self._request("DELETE", "/seller/v2/content/binary", params=params)
+
     async def enable_staged_rollout(self, content_id, rollout_rate):
         """
         Create a staged rollout for the given content id at the given rollout rate. Note that this only works for an application currently getting updated.

--- a/mozapkpublisher/sgs_api/content_info.py
+++ b/mozapkpublisher/sgs_api/content_info.py
@@ -27,25 +27,6 @@ class AppContentInfo:
                     "The app content info is missing a mandatory key: {}".format(key)
                 )
 
-        if len(self._inner.get("binaryList", [])) > 20:
-            raise SgsContentInfoException(
-                "You cannot have more than 20 binaries declared for a single content ID"
-            )
-
-    def add_binary(self, new_binary):
-        """
-        Add a binary to the binary list for this content info. If the list would exceed 20 items, the first item is popped from the list.
-        This is because the samsung API doesn't want an app to have more than 20 binaries registered at the same time.
-        """
-        binaryList = self._inner.setdefault("binaryList", [])
-
-        # Samsung only allows 20 binaries to be uploaded for a certain content ID
-        # Remove older binaries so that we get space to add our own
-        while len(binaryList) >= 20:
-            binaryList.pop(0)
-
-        binaryList.append(new_binary)
-
     @property
     def binary_list(self):
         """

--- a/mozapkpublisher/sgs_api/content_info.py
+++ b/mozapkpublisher/sgs_api/content_info.py
@@ -72,6 +72,7 @@ class AppContentInfo:
         Return this content info as a dictionary ready to be sent to the `updateContent` API.
         The following transformations are applied:
             - The `startPublicationDate` field is removed
+            - The `binaryList` field is removed as the `contentUpdate` API does not accept it when modified. Binaries are managed through their own API.
             - The `screenshots`, `addLanguage` and `sellCountryList` are nulled out as we don't support updating them and can't send them back verbatim.
             - The `publicationType` is set to "03" to set the publication time to "manual"
         """
@@ -82,6 +83,9 @@ class AppContentInfo:
         # Sometimes having this fails... Sometimes it doesn't... It makes no sense but removing it completely makes the content info upload not fail 🤷
         if "startPublicationDate" in content:
             del content["startPublicationDate"]
+
+        if "binaryList" in content:
+            del content["binaryList"]
 
         # All those need to be None so samsung knows we're not trying to update
         # them. Leaving them as is *should* be doing the same thing as we're

--- a/mozapkpublisher/test/integration/test_upload_sgs.py
+++ b/mozapkpublisher/test/integration/test_upload_sgs.py
@@ -207,7 +207,6 @@ def setup_default_sgs_api(responses):
         ],
     )
 
-    # Only repeat the response once so we can fake an upload changing binaryList.
     responses.get(
         "https://devapi.samsungapps.com/seller/contentInfo?contentId=000002975732",
         repeat=1,
@@ -221,12 +220,6 @@ def setup_default_sgs_api(responses):
         payload=[FOCUS_CONTENT_INFO],
     )
 
-    responses.get(
-        "https://devapi.samsungapps.com/seller/contentInfo?contentId=000003397900",
-        status=200,
-        payload=[UPDATED_FOCUS_CONTENT_INFO, FOCUS_CONTENT_INFO],
-    )
-
     responses.post(
         "https://devapi.samsungapps.com/seller/createUploadSessionId",
         status=200,
@@ -238,6 +231,11 @@ def setup_default_sgs_api(responses):
         payload={"fileKey": "abc", "fileSize": 15},
     )
     responses.post("https://devapi.samsungapps.com/seller/contentUpdate", status=200)
+    responses.post(
+        "https://devapi.samsungapps.com/seller/v2/content/binary",
+        status=200,
+        payload={"resultCode": "0000", "resultMessage": "Ok", "data": {"binarySeq": "306"}},
+    )
     responses.put(
         "https://devapi.samsungapps.com/seller/v2/content/stagedRolloutBinary",
         status=200,
@@ -355,45 +353,6 @@ async def test_update_ok(responses, monkeypatch, rollout_rate, submit):
         "copyrightHolder": "",
         "supportEMail": "android-marketplace-notices@mozilla.com",
         "supportedSiteUrl": "",
-        "binaryList": [
-            {
-                "fileName": "App_20250326114753061.apk",
-                "binarySeq": "304",
-                "versionCode": "390842046",
-                "versionName": "137.0",
-                "packageName": "org.mozilla.focus",
-                "nativePlatforms": "32bit",
-                "apiminSdkVersion": "21",
-                "apimaxSdkVersion": None,
-                "iapSdk": "N",
-                "gms": "Y",
-                "filekey": None,
-            },
-            {
-                "fileName": "App_20250326114759363.apk",
-                "binarySeq": "305",
-                "versionCode": "390842048",
-                "versionName": "137.0",
-                "packageName": "org.mozilla.focus",
-                "nativePlatforms": "64bit",
-                "apiminSdkVersion": "21",
-                "apimaxSdkVersion": None,
-                "iapSdk": "N",
-                "gms": "Y",
-                "filekey": None,
-            },
-            {
-                "fileName": "blob",
-                "versionCode": "390842050",
-                "binarySeq": 306,
-                "packageName": "org.mozilla.focus",
-                "apiminSdkVersion": 21,
-                "apimaxSdkversion": None,
-                "iapSdk": "N",
-                "gms": "Y",
-                "filekey": "abc",
-            },
-        ],
         "standardPrice": "0",
         "paid": "N",
         "publicationType": "03",
@@ -453,6 +412,16 @@ async def test_update_ok(responses, monkeypatch, rollout_rate, submit):
         method="POST",
         headers=basic_auth_headers(),
         json=expected_content_update,
+    )
+    responses.assert_called_with(
+        url="https://devapi.samsungapps.com/seller/v2/content/binary",
+        method="POST",
+        headers=basic_auth_headers(),
+        json={
+            "contentId": "000003397900",
+            "filekey": "abc",
+            "gms": "Y",
+        },
     )
 
     if rollout_rate is not None:

--- a/mozapkpublisher/test/sgs/test_binary.py
+++ b/mozapkpublisher/test/sgs/test_binary.py
@@ -1,0 +1,103 @@
+import pytest
+
+from contextlib import nullcontext as does_not_raise
+from .common import basic_auth_headers
+from mozapkpublisher.sgs_api.error import SgsAuthenticationException
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "status,response,expectation",
+    (
+        pytest.param(
+            401,
+            {"code": "AUTH_REQUIRE", "message": "Invalid accessToken", "from": "asgw"},
+            pytest.raises(SgsAuthenticationException, match="Invalid accessToken"),
+        ),
+        pytest.param(
+            401,
+            {
+                "code": "AUTH_REQUIRE",
+                "message": "Not found serviceAccount by serviceAccountId",
+                "from": "asgw",
+            },
+            pytest.raises(SgsAuthenticationException, match="Not found serviceAccount"),
+        ),
+        pytest.param(
+            200,
+            {"resultCode": "0000", "resultMessage": "Ok", "data": {"binarySeq": "3"}},
+            does_not_raise(),
+        ),
+    ),
+)
+async def test_add_binary(sgs, responses_mock, status, response, expectation):
+    responses_mock.post(
+        "https://devapi.samsungapps.com/seller/v2/content/binary",
+        status=status,
+        payload=response,
+    )
+
+    with expectation as exc:
+        res = await sgs.add_binary("0123456", "file-key", "N")
+
+    responses_mock.assert_called_with(
+        url="https://devapi.samsungapps.com/seller/v2/content/binary",
+        method="POST",
+        headers=basic_auth_headers(),
+        json={
+            "contentId": "0123456",
+            "filekey": "file-key",
+            "gms": "N",
+        },
+    )
+
+    if exc is None:
+        assert res["resultCode"] == "0000"
+        assert res["data"]["binarySeq"] == "3"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "status,response,expectation",
+    (
+        pytest.param(
+            401,
+            {"code": "AUTH_REQUIRE", "message": "Invalid accessToken", "from": "asgw"},
+            pytest.raises(SgsAuthenticationException, match="Invalid accessToken"),
+        ),
+        pytest.param(
+            401,
+            {
+                "code": "AUTH_REQUIRE",
+                "message": "Not found serviceAccount by serviceAccountId",
+                "from": "asgw",
+            },
+            pytest.raises(SgsAuthenticationException, match="Not found serviceAccount"),
+        ),
+        pytest.param(
+            200,
+            {"resultCode": "0000", "resultMessage": "Ok"},
+            does_not_raise(),
+        ),
+    ),
+)
+async def test_delete_binary(sgs, responses_mock, status, response, expectation):
+    responses_mock.delete(
+        "https://devapi.samsungapps.com/seller/v2/content/binary?contentId=0123456&binarySeq=1",
+        status=status,
+        payload=response,
+    )
+
+    with expectation as exc:
+        res = await sgs.delete_binary("0123456", "1")
+
+    responses_mock.assert_called_with(
+        url="https://devapi.samsungapps.com/seller/v2/content/binary",
+        method="DELETE",
+        headers=basic_auth_headers(),
+        params={"contentId": "0123456", "binarySeq": "1"},
+    )
+
+    if exc is None:
+        assert res["resultCode"] == "0000"
+        assert res["resultMessage"] == "Ok"

--- a/mozapkpublisher/test/sgs/test_content_info.py
+++ b/mozapkpublisher/test/sgs/test_content_info.py
@@ -121,3 +121,10 @@ def test_new_content_info_sets_publication_type_to_manual():
     new_content_info["publicationType"] = "00"
     content_info = AppContentInfo(new_content_info)
     assert content_info.as_new_data()["publicationType"] == "03"
+
+
+def test_new_content_info_drops_binary_list():
+    new_content_info = copy.copy(MINIMAL_VALID_CONTENT_INFO)
+    new_content_info["binaryList"] = [{"fileName": "foo", "binarySeq": "1"}]
+    content_info = AppContentInfo(new_content_info)
+    assert "binaryList" not in content_info.as_new_data()

--- a/mozapkpublisher/test/sgs/test_content_info.py
+++ b/mozapkpublisher/test/sgs/test_content_info.py
@@ -87,23 +87,6 @@ MINIMAL_VALID_CONTENT_INFO = {
 }
 
 
-def test_adding_more_than_twenty_binaries():
-    new_content_info = copy.copy(MINIMAL_VALID_CONTENT_INFO)
-    new_content_info["binaryList"] = [{"fileName": str(i)} for i in range(21)]
-
-    with pytest.raises(SgsContentInfoException, match="more than 20 binaries"):
-        content_info = AppContentInfo(new_content_info)
-
-    new_content_info["binaryList"] = [{"fileName": str(i)} for i in range(20)]
-    content_info = AppContentInfo(new_content_info)
-
-    assert len(content_info.binary_list) == 20
-    content_info.add_binary({"fileName": "foo"})
-    assert len(content_info.binary_list) == 20
-    assert content_info.binary_list[0]["fileName"] == "1"
-    assert content_info.binary_list[-1]["fileName"] == "foo"
-
-
 @pytest.mark.parametrize("key", (None, *MINIMAL_VALID_CONTENT_INFO.keys()))
 def test_creating_content_info_with_missing_key(key):
     new_content_info = copy.copy(MINIMAL_VALID_CONTENT_INFO)

--- a/mozapkpublisher/test/sgs/test_submit.py
+++ b/mozapkpublisher/test/sgs/test_submit.py
@@ -205,17 +205,19 @@ async def test_update_content_info(
         data = AppContentInfo(params)
         await sgs.update_content_info(data)
 
-        expected_extra_fields = {
-            "screenshots": None,
-            "addLanguage": None,
-            "sellCountryList": None,
-        }
-        expected_json = UPDATE_BASE_PARAMS | expected_extra_fields
         responses_mock.assert_called_with(
             url="https://devapi.samsungapps.com/seller/contentUpdate",
             method="POST",
             headers=basic_auth_headers(),
-            json=expected_json,
+            json={
+                "contentId": "foobar",
+                "defaultLanguageCode": "EN",
+                "paid": "N",
+                "publicationType": "03",
+                "screenshots": None,
+                "addLanguage": None,
+                "sellCountryList": None,
+            },
         )
 
 


### PR DESCRIPTION
Starting July 2026, the samsung galaxy store stopped accepting content updates that modified the binary list, forcing users to instead use dedicated APIs for management.

They added a `binarySeqForDeviceInfo` parameter to the binary addition. After testing I found that it dropped support for 200+ devices on focus, and that it works fine without. So I didn't bother adding support for it since the documentation is unclear about what it even does (it probably needs to be keyed by architecture, but again, it works without it
anyway).

The one change in behavior I saw is that the UI now shows the filename as uploaded instead of some weird `focus-15206-armeabi-v7a.apk`. I couldn't figure out what was setting that name before, so I assume it's something Samsung did. The new name is the one we pass in the multipart form, including dots which the web UI doesn't allow you to upload manually.

It's not causing any issue, and we know they were storing that multipart name before because it caused bug 1974870. So nothing to do here, just noting it because this is a reminder that this name has to be unique if it's ever changed.